### PR TITLE
Update pyproject.toml license key to use SPDX license identifier

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "osbng"
 version = "0.1.0"
 description = "A Python library supporting geospatial grid indexing and interaction with Ordnance Survey's British National Grid index system"
 readme = "README.md"
-license = { text = "MIT" }
+license = "MIT"
 authors = [
     {name = "Steve Kingston", email = "steve.kingston@os.uk"}, 
     {name = "Kate New", email = "kate.new@os.uk"},


### PR DESCRIPTION
# Summary

Updates the `license` key within the `project` table of the `pyproject.toml` file to use a SPDX identifier which is compatible with [PEP 621](https://peps.python.org/pep-0621/#license). Without this change the package build would eventually fail (come 2026).