### PR TITLE
Fix installation error by requiring setuptools >=77.0.3 for license metadata support (Closes #10)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ all = [
 
 [build-system]
 requires = [
-    "setuptools >=68.0", 
+    "setuptools >=77.0.3", # Ensure support for PEP 639 license metadata
     "wheel"
 ]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
# Summary 

This PR resolves #10 by updating the `setuptools` version in `pyproject.toml` to a version that supports [PEP 639](https://peps.python.org/pep-0639/) license metadata in the `[project]` table.

## Background

The `license = "MIT"` syntax in the `pyproejct.toml` is valid according to PEP 639. However, installing the package from GitHub was failing due to the installed setuptools version not recognising this metadata.