### PR TITLE
Expose main public API at the package level

### DIFF
--- a/osbng/__init__.py
+++ b/osbng/__init__.py
@@ -1,0 +1,23 @@
+"""A Python package supporting geospatial grid indexing and interaction with Ordnance Survey's British National Grid index system."""
+
+from osbng.bng_reference import BNGReference
+from osbng.grids import *
+from osbng.indexing import xy_to_bng, bbox_to_bng, geom_to_bng, geom_to_bng_intersection
+from osbng.resolution import BNG_RESOLUTIONS
+
+__all__ = [
+    "BNG_BOUNDS",
+    "BNG_RESOLUTIONS",
+    "BNGReference",
+    "bng_grid_100km",
+    "bng_grid_50km",
+    "bng_grid_10km",
+    "bng_grid_5km",
+    "bng_grid_1km",
+    "xy_to_bng",
+    "bbox_to_bng",
+    "bbox_to_bng_iterfeatures",
+    "geom_to_bng",
+    "geom_to_bng_intersection",
+]
+__version__ = "0.1.0"


### PR DESCRIPTION
# Summary

This PR populates the `osbng` package’s `__init__.py` to expose the main public API at the package level. Linked to #12 .

The key functions, classes, and constants are now directly importable from `osbng` improving usability and discoverability for end users.

## Details

* Imports core functions, classes, and constants from package modules into the package namespace e.g. `from osbng import xy_to_bng`
* Adds a module docstring and version string.