### PR TITLE
Fix setuptools package discovery

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "osbng"
-version = "0.1.0"
+version = "0.2.0"
 description = "A Python package supporting geospatial grid indexing and interaction with Ordnance Survey's British National Grid index system"
 readme = "README.md"
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ requires = [
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools.packages.find]
-where = ["osbng"]
+where = ["."]
 
 [tool.pytest.ini_options]
 addopts = "-ra"


### PR DESCRIPTION
This PR resolves #15 by pointing setuptools to find the `osbng` package/directory at the project root, not to look for packages inside the `./osbng` directory.

The package version in `pyproject.toml` is also bumped to `0.2.0` to match the package's `__init__.py` version.