### PR TITLE
Add TypedDict test case classes and expected_warning handling to traversal tests

### DIFF
--- a/tests/data/traversal_test_cases.json
+++ b/tests/data/traversal_test_cases.json
@@ -50,6 +50,17 @@
             "bng_ref_string_1": "TL 19 28",
             "bng_ref_string_2": "ST SW",
             "expected": 220323.62560560773
+        },
+        {
+            "bng_ref_string_1": "SJ",
+            "bng_ref_string_2": "SJ",
+            "expected": 0.0
+        },
+        {
+            "bng_ref_string_1": "SJ",
+            "bng_ref_string_2": "SJ",
+            "edge_to_edge": true,
+            "expected": 0.0
         }
     ],
     "bng_is_neighbour": [
@@ -152,7 +163,7 @@
             "bng_ref_string": "SU 12 34",
             "d": 999,
             "expected": {
-                "bng_ref_formatted": [                    
+                "bng_ref_formatted": [
                     "SU 11 33",
                     "SU 12 33",
                     "SU 13 33",

--- a/tests/data/traversal_test_cases.json
+++ b/tests/data/traversal_test_cases.json
@@ -141,26 +141,25 @@
                 "bng_ref_formatted": [
                     "SQ",
                     "SR",
-                    "SV",
                     "SW"
                 ]
             }
         },
         {
-            "bng_ref_string": "OM 94",
+            "bng_ref_string": "OM 9 4",
             "k": 2,
             "expected_warning": true,
             "expected": {
                 "bng_ref_formatted": [
-                    "OM 72",
-                    "OM 73",
-                    "OM 74",
-                    "OM 75",
-                    "OM 76",
-                    "OM 82",
-                    "OM 86",
-                    "OM 92",
-                    "OM 96"
+                    "OM 7 2",
+                    "OM 7 3",
+                    "OM 7 4",
+                    "OM 7 5",
+                    "OM 7 6",
+                    "OM 8 2",
+                    "OM 8 6",
+                    "OM 9 2",
+                    "OM 9 6"
                 ]
             }
         }
@@ -194,6 +193,7 @@
             "expected_warning": true,
             "expected": {
                 "bng_ref_formatted": [
+                    "HL NW",
                     "HL NE",
                     "HL SE",
                     "HL SW"
@@ -206,26 +206,26 @@
             "expected_warning": true,
             "expected": {
                 "bng_ref_formatted": [
-                    "TW 50",
-                    "TW 51",
-                    "TW 52",
-                    "TW 53",
-                    "TW 60",
-                    "TW 61",
-                    "TW 62",
-                    "TW 63",
-                    "TW 70",
-                    "TW 71",
-                    "TW 72",
-                    "TW 73",
-                    "TW 80",
-                    "TW 81",
-                    "TW 82",
-                    "TW 83",
-                    "TW 90",
-                    "TW 91",
-                    "TW 92",
-                    "TW 93"
+                    "TW 5 0",
+                    "TW 5 1",
+                    "TW 5 2",
+                    "TW 5 3",
+                    "TW 6 0",
+                    "TW 6 1",
+                    "TW 6 2",
+                    "TW 6 3",
+                    "TW 7 0",
+                    "TW 7 1",
+                    "TW 7 2",
+                    "TW 7 3",
+                    "TW 8 0",
+                    "TW 8 1",
+                    "TW 8 2",
+                    "TW 8 3",
+                    "TW 9 0",
+                    "TW 9 1",
+                    "TW 9 2",
+                    "TW 9 3"
                 ]
             }
         }

--- a/tests/data/traversal_test_cases.json
+++ b/tests/data/traversal_test_cases.json
@@ -132,6 +132,37 @@
             "bng_ref_string": "SU 12 34",
             "k": 3,
             "expected_length": 24
+        },
+        {
+            "bng_ref_string": "SV",
+            "k": 1,
+            "expected_warning": true,
+            "expected": {
+                "bng_ref_formatted": [
+                    "SQ",
+                    "SR",
+                    "SV",
+                    "SW"
+                ]
+            }
+        },
+        {
+            "bng_ref_string": "OM 94",
+            "k": 2,
+            "expected_warning": true,
+            "expected": {
+                "bng_ref_formatted": [
+                    "OM 72",
+                    "OM 73",
+                    "OM 74",
+                    "OM 75",
+                    "OM 76",
+                    "OM 82",
+                    "OM 86",
+                    "OM 92",
+                    "OM 96"
+                ]
+            }
         }
     ],
     "bng_kdisc": [
@@ -156,6 +187,47 @@
             "bng_ref_string": "SU 12 34",
             "k": 3,
             "expected_length": 49
+        },
+        {
+            "bng_ref_string": "HL NW",
+            "k": 1,
+            "expected_warning": true,
+            "expected": {
+                "bng_ref_formatted": [
+                    "HL NE",
+                    "HL SE",
+                    "HL SW"
+                ]
+            }
+        },
+        {
+            "bng_ref_string": "TW 71",
+            "k": 2,
+            "expected_warning": true,
+            "expected": {
+                "bng_ref_formatted": [
+                    "TW 50",
+                    "TW 51",
+                    "TW 52",
+                    "TW 53",
+                    "TW 60",
+                    "TW 61",
+                    "TW 62",
+                    "TW 63",
+                    "TW 70",
+                    "TW 71",
+                    "TW 72",
+                    "TW 73",
+                    "TW 80",
+                    "TW 81",
+                    "TW 82",
+                    "TW 83",
+                    "TW 90",
+                    "TW 91",
+                    "TW 92",
+                    "TW 93"
+                ]
+            }
         }
     ],
     "bng_dwithin": [

--- a/tests/data/traversal_test_cases.json
+++ b/tests/data/traversal_test_cases.json
@@ -1,66 +1,66 @@
 {
     "bng_distance": [
         {
-            "bng_ref_string_1": "SE1822",
-            "bng_ref_string_2": "SE1922",
+            "bng_ref_string_1": "SE 18 22",
+            "bng_ref_string_2": "SE 19 22",
             "expected": 1000.0
         },
         {
-            "bng_ref_string_1": "SE1822",
-            "bng_ref_string_2": "SE1922",
+            "bng_ref_string_1": "SE 18 22",
+            "bng_ref_string_2": "SE 19 22",
             "edge_to_edge": true,
             "expected": 0.0
         },
         {
-            "bng_ref_string_1": "SE12",
-            "bng_ref_string_2": "SE13",
+            "bng_ref_string_1": "SE 12",
+            "bng_ref_string_2": "SE 13",
             "expected": 10000.0
         },
         {
-            "bng_ref_string_1": "SE12",
-            "bng_ref_string_2": "SE14",
+            "bng_ref_string_1": "SE 12",
+            "bng_ref_string_2": "SE 14",
             "expected": 20000.0
         },
         {
-            "bng_ref_string_1": "TL2029",
-            "bng_ref_string_2": "TL2130",
+            "bng_ref_string_1": "TL 20 29",
+            "bng_ref_string_2": "TL 21 30",
             "expected": 1414.213562373095
         },
         {
-            "bng_ref_string_1": "TL1928",
-            "bng_ref_string_2": "TL2231",
+            "bng_ref_string_1": "TL 19 28",
+            "bng_ref_string_2": "TL 22 31",
             "expected": 4242.640687119285
         },
         {
-            "bng_ref_string_1": "SE0718",
-            "bng_ref_string_2": "SE0922",
+            "bng_ref_string_1": "SE 07 18",
+            "bng_ref_string_2": "SE 09 22",
             "expected": 4472.13595499958
         },
         {
-            "bng_ref_string_1": "SE1118",
-            "bng_ref_string_2": "SE22NW",
+            "bng_ref_string_1": "SE 11 18",
+            "bng_ref_string_2": "SE 22 NW",
             "expected": 14212.670403551896
         },
         {
-            "bng_ref_string_1": "STSW",
-            "bng_ref_string_2": "TASW",
+            "bng_ref_string_1": "ST SW",
+            "bng_ref_string_2": "TA SW",
             "expected": 360555.1275463989
         },
         {
-            "bng_ref_string_1": "TL1928",
-            "bng_ref_string_2": "STSW",
+            "bng_ref_string_1": "TL 19 28",
+            "bng_ref_string_2": "ST SW",
             "expected": 220323.62560560773
         }
     ],
     "bng_is_neighbour": [
         {
-            "bng_ref_string_1": "SE1822",
-            "bng_ref_string_2": "SE1922",
+            "bng_ref_string_1": "SE 18 22",
+            "bng_ref_string_2": "SE 19 22",
             "expected": true
         },
         {
-            "bng_ref_string_1": "SE1822",
-            "bng_ref_string_2": "SE1721",
+            "bng_ref_string_1": "SE 18 22",
+            "bng_ref_string_2": "SE 17 21",
             "expected": false
         },
         {
@@ -80,29 +80,29 @@
         },
         {
             "bng_ref_string_1": "SE",
-            "bng_ref_string_2": "TA0030",
+            "bng_ref_string_2": "TA 00 30",
             "expected_exception": {
                 "name": "BNGNeighbourError",
                 "message": "The input BNG Resolution objects are not the same grid resolution. The input BNG Resolution objects must be the same grid resolution."
             }
         },
         {
-            "bng_ref_string_1": "SPSE",
-            "bng_ref_string_2": "TL02",
+            "bng_ref_string_1": "SP SE",
+            "bng_ref_string_2": "TL 02",
             "expected_exception": {
                 "name": "BNGNeighbourError",
                 "message": "The input BNG Resolution objects are not the same grid resolution. The input BNG Resolution objects must be the same grid resolution."
             }
         },
         {
-            "bng_ref_string_1": "SPSE",
-            "bng_ref_string_2": "SPSE",
+            "bng_ref_string_1": "SP SE",
+            "bng_ref_string_2": "SP SE",
             "expected": false
         }
     ],
     "bng_kring": [
         {
-            "bng_ref_string": "SU1234",
+            "bng_ref_string": "SU 12 34",
             "k": 1,
             "expected": {
                 "bng_ref_formatted": [
@@ -118,14 +118,14 @@
             }
         },
         {
-            "bng_ref_string": "SU1234",
+            "bng_ref_string": "SU 12 34",
             "k": 3,
             "expected_length": 24
         }
     ],
     "bng_kdisc": [
         {
-            "bng_ref_string": "SU1234",
+            "bng_ref_string": "SU 12 34",
             "k": 1,
             "expected": {
                 "bng_ref_formatted": [
@@ -142,14 +142,14 @@
             }
         },
         {
-            "bng_ref_string": "SU1234",
+            "bng_ref_string": "SU 12 34",
             "k": 3,
             "expected_length": 49
         }
     ],
     "bng_dwithin": [
         {
-            "bng_ref_string": "SU1234",
+            "bng_ref_string": "SU 12 34",
             "d": 999,
             "expected": {
                 "bng_ref_formatted": [                    
@@ -166,7 +166,7 @@
             }
         },
         {
-            "bng_ref_string": "SU1234",
+            "bng_ref_string": "SU 12 34",
             "d": 1001,
             "expected_length": 21
         }

--- a/tests/test_traversal.py
+++ b/tests/test_traversal.py
@@ -22,7 +22,7 @@ class BNGDistanceTestCase(TypedDict):
         bng_ref_string_1 (str): The first BNG reference string.
         bng_ref_string_2 (str): The second BNG reference string.
         edge_to_edge (bool | None): Whether to calculate edge-to-edge distance.
-        expected (float): The distance expected between the two BNG references.
+        expected (float): The expected distance between the pair of BNGReference objects.
     """
 
     bng_ref_string_1: str
@@ -43,6 +43,7 @@ def test_bng_distance(test_case: BNGDistanceTestCase):
     Args:
         test_case (BNGDistanceTestCase): The test case from JSON file.
     """
+    # Load test case data
     bng_ref1 = test_case["bng_ref_string_1"]
     bng_ref2 = test_case["bng_ref_string_2"]
 

--- a/tests/test_traversal.py
+++ b/tests/test_traversal.py
@@ -128,12 +128,14 @@ class BNGKRingTestCase(TypedDict):
     Attributes:
         bng_ref_string (str): The BNG reference string.
         k (int): The k value for the k-ring.
+        expected_warning (bool | None): The expected warning is a boolean indicating if a warning is expected.
         expected (dict[str, list[str]] | None): The expected result is a dictionary with the key "bng_ref_formatted" and a list of formatted BNG reference strings.
         expected_length (int | None): The expected length of the k-ring. Represents the number of BNGReference objects within k-ring.
     """
 
     bng_ref_string: str
     k: int
+    expected_warning: bool | None
     expected: dict[str, list[str]] | None
     expected_length: int | None
 
@@ -166,12 +168,14 @@ class BNGKDiscTestCase(TypedDict):
     Attributes:
         bng_ref_string (str): The BNG reference string.
         k (int): The k value for the k-disc.
+        expected_warning (bool | None): The expected warning is a boolean indicating if a warning is expected.
         expected (dict[str, list[str]] | None): The expected result is a dictionary with the key "bng_ref_formatted" and a list of formatted BNG reference strings.
         expected_length (int | None): The expected length of the k-disc. Represents the number of BNGReference objects within k-disc.
     """
 
     bng_ref_string: str
     k: int
+    expected_warning: bool | None
     expected: dict[str, list[str]] | None
     expected_length: int | None
 

--- a/tests/test_traversal.py
+++ b/tests/test_traversal.py
@@ -7,10 +7,10 @@ The test cases are defined as TypedDicts, which provide a way to define the stru
 
 import pytest
 
-from osbng.traversal import *
-from osbng.errors import _EXCEPTION_MAP
-from osbng.utils import _load_test_cases
 from osbng.bng_reference import BNGReference
+from osbng.errors import _EXCEPTION_MAP
+from osbng.traversal import *
+from osbng.utils import _load_test_cases
 
 
 # Parameterised test for bng_distance function

--- a/tests/test_traversal.py
+++ b/tests/test_traversal.py
@@ -34,23 +34,33 @@ class BNGDistanceTestCase(TypedDict):
 # Parameterised test for bng_distance function
 @pytest.mark.parametrize(
     "test_case",
+    # Load test cases from JSON file
     _load_test_cases(file_path="./data/traversal_test_cases.json")["bng_distance"],
 )
 def test_bng_distance(test_case: BNGDistanceTestCase):
-    """Test bng_distance with test cases from JSON file."""
+    """Test bng_distance with test cases from JSON file.
+    
+    Args:
+        test_case (BNGDistanceTestCase): The test case from JSON file.
+    """
     bng_ref1 = test_case["bng_ref_string_1"]
     bng_ref2 = test_case["bng_ref_string_2"]
     if "expected_exception" in test_case:
+        # Get exception name from test case
         exception_name = test_case["expected_exception"]["name"]
         # Get exception class from name
         exception_class = _EXCEPTION_MAP[exception_name]
+        # Assert that the test case raises the expected exception
         with pytest.raises(exception_class):
             bng_distance(BNGReference(bng_ref1), BNGReference(bng_ref2))
     elif "edge_to_edge" in test_case:
+        # If edge_to_edge is specified, use it in the distance calculation
         edge_to_edge = test_case["edge_to_edge"]
+        # Assert that the function returns the expected result
         distance = bng_distance(BNGReference(bng_ref1), BNGReference(bng_ref2), edge_to_edge=edge_to_edge)
         assert distance == test_case["expected"]
     else:
+        # Assert that the function returns the expected result
         distance = bng_distance(BNGReference(bng_ref1), BNGReference(bng_ref2))
         assert distance == test_case["expected"]
 
@@ -74,14 +84,22 @@ class BNGIsNeighbourTestCase(TypedDict):
 # Parameterised test for bng_is_neighbour function
 @pytest.mark.parametrize(
     "test_case",
+    # Load test cases from JSON file
     _load_test_cases(file_path="./data/traversal_test_cases.json")["bng_is_neighbour"],
 )
 def test_bng_is_neighbour(test_case: BNGIsNeighbourTestCase):
-    """Test bng_is_neighbour with test cases from JSON file."""
+    """Test bng_is_neighbour with test cases from JSON file.
+    
+    Args:
+        test_case (BNGIsNeighbourTestCase): The test case from JSON file.
+    """
+    # Load test case data
     bng_ref1 = test_case["bng_ref_string_1"]
     bng_ref2 = test_case["bng_ref_string_2"]
     if "expected_exception" in test_case:
+        # Get exception name from test case
         exception_name = test_case["expected_exception"]["name"]
+        # Get exception message from test case
         message = (
             None
             if test_case["expected_exception"]["name"] == "BNGNeighbourError"
@@ -89,9 +107,11 @@ def test_bng_is_neighbour(test_case: BNGIsNeighbourTestCase):
         )
         # Get exception class from name
         exception_class = _EXCEPTION_MAP[exception_name]
+        # Assert that the test case raises the expected exception
         with pytest.raises(exception_class, match=message):
             bng_is_neighbour(BNGReference(bng_ref1), BNGReference(bng_ref2))
     else:
+        # Assert that the function returns the expected result
         distance = bng_is_neighbour(BNGReference(bng_ref1), BNGReference(bng_ref2))
         assert distance == test_case["expected"]
 
@@ -115,14 +135,20 @@ class BNGKRingTestCase(TypedDict):
 # Parameterised test for bng_kring function
 @pytest.mark.parametrize(
     "test_case",
+    # Load test cases from JSON file
     _load_test_cases(file_path="./data/traversal_test_cases.json")["bng_kring"],
 )
 def test_bng_kring(test_case: BNGKRingTestCase):
-    """Test bng_kring with test cases from JSON file."""
-
+    """Test bng_kring with test cases from JSON file.
+    
+    Args:
+        test_case (BNGKRingTestCase): The test case from JSON file.
+    """
     if "expected_length" in test_case:
+        # Assert that the function returns the expected length
         assert len(bng_kring(BNGReference(test_case["bng_ref_string"]), test_case["k"])) == test_case["expected_length"]
     else:
+        # Assert that the function returns the expected result
         kring = bng_kring(BNGReference(test_case["bng_ref_string"]), test_case["k"])
         assert sorted([r.bng_ref_formatted for r in kring]) == sorted(test_case["expected"]["bng_ref_formatted"])
 
@@ -146,14 +172,20 @@ class BNGKDiscTestCase(TypedDict):
 # Parameterised test for bng_kdisc function
 @pytest.mark.parametrize(
     "test_case",
+    # Load test cases from JSON file
     _load_test_cases(file_path="./data/traversal_test_cases.json")["bng_kdisc"],
 )
 def test_bng_kdisc(test_case: BNGKDiscTestCase):
-    """Test bng_kdisc with test cases from JSON file."""
-
+    """Test bng_kdisc with test cases from JSON file.
+    
+    Args:
+        test_case (BNGKDiscTestCase): The test case from JSON file.
+    """
     if "expected_length" in test_case:
+        # Assert that the function returns the expected length
         assert len(bng_kdisc(BNGReference(test_case["bng_ref_string"]), test_case["k"])) == test_case["expected_length"]
     else:
+        # Assert that the function returns the expected result
         kring = bng_kdisc(BNGReference(test_case["bng_ref_string"]), test_case["k"])
         assert sorted([r.bng_ref_formatted for r in kring]) == sorted(test_case["expected"]["bng_ref_formatted"])
 
@@ -177,14 +209,20 @@ class BNGKDWithinTestCase(TypedDict):
 # Parameterised test for bng_dwithin function
 @pytest.mark.parametrize(
     "test_case",
+    # Load test cases from JSON file
     _load_test_cases(file_path="./data/traversal_test_cases.json")["bng_dwithin"],
 )
 def test_bng_dwithin(test_case: BNGKDWithinTestCase):
-    """Test bng_dwithin with test cases from JSON file."""
-
+    """Test bng_dwithin with test cases from JSON file.
+    
+    Args:
+        test_case (BNGKDWithinTestCase): The test case from JSON file.
+    """
     if "expected_length" in test_case:
+        # Assert that the function returns the expected length
         assert len(bng_dwithin(BNGReference(test_case["bng_ref_string"]), test_case["d"])) == test_case["expected_length"]
     else:
+        # Assert that the function returns the expected result
         kring = bng_dwithin(BNGReference(test_case["bng_ref_string"]), test_case["d"])
         assert sorted([r.bng_ref_formatted for r in kring]) == sorted(test_case["expected"]["bng_ref_formatted"])
 

--- a/tests/test_traversal.py
+++ b/tests/test_traversal.py
@@ -5,6 +5,8 @@ Test cases are loaded from the JSON file using the _load_test_cases function, wh
 The test cases are defined as TypedDicts, which provide a way to define the structure of the test case data.
 """
 
+from typing import TypedDict
+
 import pytest
 
 from osbng.bng_reference import BNGReference
@@ -13,12 +15,28 @@ from osbng.traversal import *
 from osbng.utils import _load_test_cases
 
 
+class BNGDistanceTestCase(TypedDict):
+    """TypedDict for bng_distance function test cases.
+
+    Attributes:
+        bng_ref_string_1 (str): The first BNG reference string.
+        bng_ref_string_2 (str): The second BNG reference string.
+        edge_to_edge (bool | None): Whether to calculate edge-to-edge distance.
+        expected (float): The distance expected between the two BNG references.
+    """
+
+    bng_ref_string_1: str
+    bng_ref_string_2: str
+    edge_to_edge: bool | None
+    expected: float
+
+
 # Parameterised test for bng_distance function
 @pytest.mark.parametrize(
     "test_case",
     _load_test_cases(file_path="./data/traversal_test_cases.json")["bng_distance"],
 )
-def test_bng_distance(test_case):
+def test_bng_distance(test_case: BNGDistanceTestCase):
     """Test bng_distance with test cases from JSON file."""
     bng_ref1 = test_case["bng_ref_string_1"]
     bng_ref2 = test_case["bng_ref_string_2"]
@@ -37,12 +55,28 @@ def test_bng_distance(test_case):
         assert distance == test_case["expected"]
 
 
+class BNGIsNeighbourTestCase(TypedDict):
+    """TypedDict for bng_is_neighbour function test cases.
+
+    Attributes:
+        bng_ref_string_1 (str): The first BNG reference string.
+        bng_ref_string_2 (str): The second BNG reference string.
+        expected_exception (dict[str, str] | None): The expected exception is a dictionary with the exception name and message.
+        expected (bool | None): The expected result of the neighbour check.
+    """
+
+    bng_ref_string_1: str
+    bng_ref_string_2: str
+    expected_exception: dict[str, str] | None
+    expected: bool | None
+
+
 # Parameterised test for bng_is_neighbour function
 @pytest.mark.parametrize(
     "test_case",
     _load_test_cases(file_path="./data/traversal_test_cases.json")["bng_is_neighbour"],
 )
-def test_bng_is_neighbour(test_case):
+def test_bng_is_neighbour(test_case: BNGIsNeighbourTestCase):
     """Test bng_is_neighbour with test cases from JSON file."""
     bng_ref1 = test_case["bng_ref_string_1"]
     bng_ref2 = test_case["bng_ref_string_2"]
@@ -62,12 +96,28 @@ def test_bng_is_neighbour(test_case):
         assert distance == test_case["expected"]
 
 
+class BNGKRingTestCase(TypedDict):
+    """TypedDict for bng_kring function test cases.
+
+    Attributes:
+        bng_ref_string (str): The BNG reference string.
+        k (int): The k value for the k-ring.
+        expected (dict[str, list[str]] | None): The expected result is a dictionary with the key "bng_ref_formatted" and a list of formatted BNG reference strings.
+        expected_length (int | None): The expected length of the k-ring. Represents the number of BNGReference objects within k-ring.
+    """
+
+    bng_ref_string: str
+    k: int
+    expected: dict[str, list[str]] | None
+    expected_length: int | None
+
+
 # Parameterised test for bng_kring function
 @pytest.mark.parametrize(
     "test_case",
     _load_test_cases(file_path="./data/traversal_test_cases.json")["bng_kring"],
 )
-def test_bng_kring(test_case):
+def test_bng_kring(test_case: BNGKRingTestCase):
     """Test bng_kring with test cases from JSON file."""
 
     if "expected_length" in test_case:
@@ -77,12 +127,28 @@ def test_bng_kring(test_case):
         assert sorted([r.bng_ref_formatted for r in kring]) == sorted(test_case["expected"]["bng_ref_formatted"])
 
 
+class BNGKDiscTestCase(TypedDict):
+    """TypedDict for bng_kdisc function test cases.
+
+    Attributes:
+        bng_ref_string (str): The BNG reference string.
+        k (int): The k value for the k-disc.
+        expected (dict[str, list[str]] | None): The expected result is a dictionary with the key "bng_ref_formatted" and a list of formatted BNG reference strings.
+        expected_length (int | None): The expected length of the k-disc. Represents the number of BNGReference objects within k-disc.
+    """
+
+    bng_ref_string: str
+    k: int
+    expected: dict[str, list[str]] | None
+    expected_length: int | None
+
+
 # Parameterised test for bng_kdisc function
 @pytest.mark.parametrize(
     "test_case",
     _load_test_cases(file_path="./data/traversal_test_cases.json")["bng_kdisc"],
 )
-def test_bng_kdisc(test_case):
+def test_bng_kdisc(test_case: BNGKDiscTestCase):
     """Test bng_kdisc with test cases from JSON file."""
 
     if "expected_length" in test_case:
@@ -92,12 +158,28 @@ def test_bng_kdisc(test_case):
         assert sorted([r.bng_ref_formatted for r in kring]) == sorted(test_case["expected"]["bng_ref_formatted"])
 
 
+class BNGKDWithinTestCase(TypedDict):
+    """TypedDict for bng_dwithin function test cases.
+
+    Attributes:
+        bng_ref_string (str): The BNG reference string.
+        d (int): The d value for the d-within search.
+        expected (dict[str, list[str]] | None): The expected result is a dictionary with the key "bng_ref_formatted" and a list of formatted BNG reference strings.
+        expected_length (int | None): The expected length of the d-within search. Represents the number of BNGReference objects within d-within search.
+    """
+
+    bng_ref_string: str
+    d: int
+    expected: dict[str, list[str]] | None
+    expected_length: int | None
+
+
 # Parameterised test for bng_dwithin function
 @pytest.mark.parametrize(
     "test_case",
     _load_test_cases(file_path="./data/traversal_test_cases.json")["bng_dwithin"],
 )
-def test_bng_dwithin(test_case):
+def test_bng_dwithin(test_case: BNGKDWithinTestCase):
     """Test bng_dwithin with test cases from JSON file."""
 
     if "expected_length" in test_case:

--- a/tests/test_traversal.py
+++ b/tests/test_traversal.py
@@ -45,6 +45,7 @@ def test_bng_distance(test_case: BNGDistanceTestCase):
     """
     bng_ref1 = test_case["bng_ref_string_1"]
     bng_ref2 = test_case["bng_ref_string_2"]
+
     if "expected_exception" in test_case:
         # Get exception name from test case
         exception_name = test_case["expected_exception"]["name"]
@@ -53,12 +54,14 @@ def test_bng_distance(test_case: BNGDistanceTestCase):
         # Assert that the test case raises the expected exception
         with pytest.raises(exception_class):
             bng_distance(BNGReference(bng_ref1), BNGReference(bng_ref2))
+
     elif "edge_to_edge" in test_case:
         # If edge_to_edge is specified, use it in the distance calculation
         edge_to_edge = test_case["edge_to_edge"]
         # Assert that the function returns the expected result
         distance = bng_distance(BNGReference(bng_ref1), BNGReference(bng_ref2), edge_to_edge=edge_to_edge)
         assert distance == test_case["expected"]
+
     else:
         # Assert that the function returns the expected result
         distance = bng_distance(BNGReference(bng_ref1), BNGReference(bng_ref2))
@@ -96,6 +99,7 @@ def test_bng_is_neighbour(test_case: BNGIsNeighbourTestCase):
     # Load test case data
     bng_ref1 = test_case["bng_ref_string_1"]
     bng_ref2 = test_case["bng_ref_string_2"]
+
     if "expected_exception" in test_case:
         # Get exception name from test case
         exception_name = test_case["expected_exception"]["name"]
@@ -110,6 +114,7 @@ def test_bng_is_neighbour(test_case: BNGIsNeighbourTestCase):
         # Assert that the test case raises the expected exception
         with pytest.raises(exception_class, match=message):
             bng_is_neighbour(BNGReference(bng_ref1), BNGReference(bng_ref2))
+
     else:
         # Assert that the function returns the expected result
         distance = bng_is_neighbour(BNGReference(bng_ref1), BNGReference(bng_ref2))
@@ -147,6 +152,7 @@ def test_bng_kring(test_case: BNGKRingTestCase):
     if "expected_length" in test_case:
         # Assert that the function returns the expected length
         assert len(bng_kring(BNGReference(test_case["bng_ref_string"]), test_case["k"])) == test_case["expected_length"]
+    
     else:
         # Assert that the function returns the expected result
         kring = bng_kring(BNGReference(test_case["bng_ref_string"]), test_case["k"])
@@ -184,6 +190,7 @@ def test_bng_kdisc(test_case: BNGKDiscTestCase):
     if "expected_length" in test_case:
         # Assert that the function returns the expected length
         assert len(bng_kdisc(BNGReference(test_case["bng_ref_string"]), test_case["k"])) == test_case["expected_length"]
+    
     else:
         # Assert that the function returns the expected result
         kring = bng_kdisc(BNGReference(test_case["bng_ref_string"]), test_case["k"])
@@ -221,6 +228,7 @@ def test_bng_dwithin(test_case: BNGKDWithinTestCase):
     if "expected_length" in test_case:
         # Assert that the function returns the expected length
         assert len(bng_dwithin(BNGReference(test_case["bng_ref_string"]), test_case["d"])) == test_case["expected_length"]
+    
     else:
         # Assert that the function returns the expected result
         kring = bng_dwithin(BNGReference(test_case["bng_ref_string"]), test_case["d"])

--- a/tests/test_traversal.py
+++ b/tests/test_traversal.py
@@ -1,6 +1,8 @@
 """Testing for the traversal module.
 
-Test cases are loaded from a JSON file using the _load_test_cases function from the utils module.
+The test cases are defined in the JSON file located at ./data/traversal_test_cases.json and are used to parameterise the tests for various functions in the traversal module.
+Test cases are loaded from the JSON file using the _load_test_cases function, which is defined in the utils module.
+The test cases are defined as TypedDicts, which provide a way to define the structure of the test case data.
 """
 
 import pytest

--- a/tests/test_traversal.py
+++ b/tests/test_traversal.py
@@ -152,14 +152,28 @@ def test_bng_kring(test_case: BNGKRingTestCase):
     Args:
         test_case (BNGKRingTestCase): The test case from JSON file.
     """
+    # Load test case data
+    bng_ref_string = test_case["bng_ref_string"]
+    k = test_case["k"]
+    # Get expected result
+    expected = None if "expected_length" in test_case else test_case["expected"]["bng_ref_formatted"]
+    expected_length = None if "expected" in test_case else test_case["expected_length"]
+
     if "expected_length" in test_case:
         # Assert that the function returns the expected length
-        assert len(bng_kring(BNGReference(test_case["bng_ref_string"]), test_case["k"])) == test_case["expected_length"]
+        assert len(bng_kring(BNGReference(bng_ref_string), k)) == expected_length
+
+    elif "expected_warning" in test_case:
+        # Assert that the test case raises a warning
+        with pytest.warns(UserWarning):
+            # Assert that the function returns the expected result
+            kring = bng_kring(BNGReference(bng_ref_string), k)
+            assert sorted([r.bng_ref_formatted for r in kring]) == sorted(expected)
     
     else:
         # Assert that the function returns the expected result
-        kring = bng_kring(BNGReference(test_case["bng_ref_string"]), test_case["k"])
-        assert sorted([r.bng_ref_formatted for r in kring]) == sorted(test_case["expected"]["bng_ref_formatted"])
+        kring = bng_kring(BNGReference(bng_ref_string), k)
+        assert sorted([r.bng_ref_formatted for r in kring]) == sorted(expected)
 
 
 class BNGKDiscTestCase(TypedDict):
@@ -192,14 +206,28 @@ def test_bng_kdisc(test_case: BNGKDiscTestCase):
     Args:
         test_case (BNGKDiscTestCase): The test case from JSON file.
     """
+    # Load test case data
+    bng_ref_string = test_case["bng_ref_string"]
+    k = test_case["k"]
+    # Get expected result
+    expected = None if "expected_length" in test_case else test_case["expected"]["bng_ref_formatted"]
+    expected_length = None if "expected" in test_case else test_case["expected_length"]
+
     if "expected_length" in test_case:
         # Assert that the function returns the expected length
-        assert len(bng_kdisc(BNGReference(test_case["bng_ref_string"]), test_case["k"])) == test_case["expected_length"]
+        assert len(bng_kdisc(BNGReference(bng_ref_string), k)) == expected_length
+
+    elif "expected_warning" in test_case:
+        # Assert that the test case raises a warning
+        with pytest.warns(UserWarning):
+            # Assert that the function returns the expected result
+            kdisc = bng_kdisc(BNGReference(bng_ref_string), k)
+            assert sorted([r.bng_ref_formatted for r in kdisc]) == sorted(expected)
     
     else:
         # Assert that the function returns the expected result
-        kring = bng_kdisc(BNGReference(test_case["bng_ref_string"]), test_case["k"])
-        assert sorted([r.bng_ref_formatted for r in kring]) == sorted(test_case["expected"]["bng_ref_formatted"])
+        kdisc = bng_kdisc(BNGReference(bng_ref_string), k)
+        assert sorted([r.bng_ref_formatted for r in kdisc]) == sorted(expected)
 
 
 class BNGKDWithinTestCase(TypedDict):


### PR DESCRIPTION
This PR resolves #19.

This PR improves the testing for the `osbng.traversal` module by introducing explicit `TypedDict` classes for all test case inputs loaded from JSON. This change brings the traversal tests in line with the structure and documentation used in other test modules. Additional improvements include additional test documentation and support for user warnings.

Details:

* Added `TypedDict` test case classes so that each test function now uses a dedicated class to define the structure and types of its test case data.

* Test function comments and docstrings added or improved comments and docstrings for all test functions.

* Support for `expected_warning` Boolean field to the `BNGKRingTestCase` and `BNGKDiscTestCase` classes and corresponding JSON test cases.
 Test logic now checks for this field and asserts that a `UserWarning` is raised when expected.

