### PR TITLE
Update BNGReference decorators to support positional and keyword and positional arguments

### DIFF
--- a/osbng/bng_reference.py
+++ b/osbng/bng_reference.py
@@ -688,28 +688,44 @@ class BNGReference:
 
 
 def _validate_bngreference(func):
-    """Decorator to validate that the first positional argument of a function is a BNGReference object."""
+    """Decorator to validate that a BNGReference object is passed as either the first positional argument or as the bng_ref keyword argument."""
 
     @wraps(func)
     def wrapper(*args, **kwargs):
-        if not isinstance(args[0], BNGReference):
-            raise TypeError(
-                f"First argument must be a BNGReference object, got: {type(args[0])}"
-            )
-        return func(*args, **kwargs)
+        # Validate first positional argument
+        if args and isinstance(args[0], BNGReference):
+            return func(*args, **kwargs)
+
+        # Validate bng_ref keyword argument
+        if "bng_ref" in kwargs and isinstance(kwargs["bng_ref"], BNGReference):
+            return func(*args, **kwargs)
+
+        # Raise TypeError if neither condition is met
+        raise TypeError(
+            "A BNGReference object must be provided as the first positional argument or as the bng_ref keyword argument."
+        )
 
     return wrapper
 
 
 def _validate_bngreference_pair(func):
-    """Decorator to validate that the first two positional arguments of a function are BNGReference objects."""
+    """Decorator to validate that two BNGReference objects are passed as either the first two positional arguments or as the bng_ref1 and bng_ref2 keyword arguments."""
 
     @wraps(func)
     def wrapper(*args, **kwargs):
-        if not (isinstance(args[0], BNGReference) & isinstance(args[1], BNGReference)):
-            raise TypeError(
-                f"First two arguments must be a BNGReference object, got: {type(args[0])} and {type(args[1])}"
-            )
-        return func(*args, **kwargs)
+        # Validate first two positional arguments
+        if len(args) >= 2 and isinstance(args[0], BNGReference) and isinstance(args[1], BNGReference):
+            return func(*args, **kwargs)
+
+        # Validate bng_ref1 and bng_ref2 keyword arguments
+        if (
+            "bng_ref1" in kwargs and isinstance(kwargs["bng_ref1"], BNGReference) and
+            "bng_ref2" in kwargs and isinstance(kwargs["bng_ref2"], BNGReference)
+        ):
+            return func(*args, **kwargs)
+
+        raise TypeError(
+            "Two BNGReference objects must be provided as the first two positional arguments or as the bng_ref1 and bng_ref2 keyword arguments."
+        )
 
     return wrapper


### PR DESCRIPTION
This PR resolves #16.

# Summary

Updates the `_validate_bngreference` and `_validate_bngreference_pair` decorators in `osbng.bng_reference` to improve flexibility and robustness when validating `BNGReference` arguments.

**_validate_bngreference**

Now accepts a `BNGReference` object as either the first positional argument or as the `bng_ref` keyword argument.

**_validate_bngreference_pair**

Now accepts two `BNGReference` objects as either the first two positional arguments or as the `bng_ref1` and `bng_ref2` keyword arguments.