### PR TITLE
Require keyword-only arguments in some functions

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -40,7 +40,7 @@ keywords:
   - british national grid
   - ordnance survey grid
 license: MIT
-version: 0.2.1
+version: 0.3.0
 date-released: 2025-06-25
 preferred-citation:
   type: software

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -40,7 +40,7 @@ keywords:
   - british national grid
   - ordnance survey grid
 license: MIT
-version: 0.2.0
+version: 0.2.1
 date-released: 2025-06-25
 preferred-citation:
   type: software

--- a/osbng/__init__.py
+++ b/osbng/__init__.py
@@ -20,4 +20,4 @@ __all__ = [
     "geom_to_bng",
     "geom_to_bng_intersection",
 ]
-__version__ = "0.2.1"
+__version__ = "0.3.0"

--- a/osbng/__init__.py
+++ b/osbng/__init__.py
@@ -20,4 +20,4 @@ __all__ = [
     "geom_to_bng",
     "geom_to_bng_intersection",
 ]
-__version__ = "0.2.0"
+__version__ = "0.2.1"

--- a/osbng/bng_reference.py
+++ b/osbng/bng_reference.py
@@ -509,9 +509,7 @@ class BNGReference:
 
         Args:
             k (int): Grid distance in units of grid squares.
-
-        Kwargs:
-            return_relations (bool): If True, returns a list of (BNGReference, dx, dy) tuples where dx, dy are integer offsets in 
+            return_relations (bool, optional): If True, returns a list of (BNGReference, dx, dy) tuples where dx, dy are integer offsets in 
                 grid units.  If False (default), returns a list of BNGReference objects.
 
         Returns:
@@ -548,9 +546,7 @@ class BNGReference:
 
         Args:
             k (int): Grid distance in units of grid squares.
-
-        Kwargs:
-            return_relations (bool): If True, returns a list of (BNGReference, dx, dy) tuples where dx, dy are integer offsets in 
+            return_relations (bool, optional): If True, returns a list of (BNGReference, dx, dy) tuples where dx, dy are integer offsets in 
                 grid units.  If False (default), returns a list of BNGReference objects.
 
         Returns:
@@ -590,9 +586,7 @@ class BNGReference:
 
         Args:
             bng_ref2 (BNGReference): A BNGReference object.
-
-        Kwargs:
-            edge_to_edge (bool): If False (default), distance will be centroid-to-centroid distance.
+            edge_to_edge (bool, optional): If False (default), distance will be centroid-to-centroid distance.
                 If True, distance will be the shortest distance between any point in the grid squares.
 
         Returns:

--- a/osbng/hierarchy.py
+++ b/osbng/hierarchy.py
@@ -37,9 +37,7 @@ def bng_to_children(bng_ref: BNGReference, *, resolution: int | str | None = Non
 
     Args:
         bng_ref (BNGReference): The BNGReference object to derive children from.
-
-    Kwargs:
-        resolution (int | str | None): The resolution of the children BNGReference objects expressed either as a
+        resolution (int | str | None, optional): The resolution of the children BNGReference objects expressed either as a
             metre-based integer or as a string label. Defaults to None. Keyword only.
 
     Returns:
@@ -110,9 +108,7 @@ def bng_to_parent(bng_ref: BNGReference, *, resolution: int | str | None = None)
 
     Args:
         bng_ref (BNGReference): The BNGReference object to derive parent from.
-
-    Kwargs:
-        resolution (int | str | None): The resolution of the parent BNGReference objects expressed either as a
+        resolution (int | str | None, optional): The resolution of the parent BNGReference objects expressed either as a
             metre-based integer or as a string label. Defaults to None. Keyword only.
 
     Returns:

--- a/osbng/hierarchy.py
+++ b/osbng/hierarchy.py
@@ -26,7 +26,7 @@ __all__ = ["bng_to_children", "bng_to_parent"]
 
 
 @_validate_bngreference
-def bng_to_children(bng_ref: BNGReference, resolution: int | str | None = None) -> list[BNGReference]:
+def bng_to_children(bng_ref: BNGReference, *, resolution: int | str | None = None) -> list[BNGReference]:
     """Returns a list of BNGReference objects that are children of the input BNGReference object.
 
     By default, the children of the BNGReference object is defined as the BNGReference objects in the
@@ -96,7 +96,7 @@ def bng_to_children(bng_ref: BNGReference, resolution: int | str | None = None) 
 
 
 @_validate_bngreference
-def bng_to_parent(bng_ref: BNGReference, resolution: int | str | None = None) -> BNGReference:
+def bng_to_parent(bng_ref: BNGReference, *, resolution: int | str | None = None) -> BNGReference:
     """Returns a BNGReference object that is the parent of the input BNGReference object.
 
     By default, the parent of the BNGReference object is defined as the BNGReference in the next BNG

--- a/osbng/hierarchy.py
+++ b/osbng/hierarchy.py
@@ -84,8 +84,8 @@ def bng_to_children(bng_ref: BNGReference, *, resolution: int | str | None = Non
         )
 
     # Get min and max coordinates of the grid square bounding box
-    min_coords = bng_to_xy(bng_ref, "lower-left")
-    max_coords = bng_to_xy(bng_ref, "upper-right")
+    min_coords = bng_to_xy(bng_ref, position="lower-left")
+    max_coords = bng_to_xy(bng_ref, position="upper-right")
 
     # Derive children BNGReference objects from the bounding box
     bng_refs = bbox_to_bng(
@@ -153,7 +153,7 @@ def bng_to_parent(bng_ref: BNGReference, *, resolution: int | str | None = None)
         )
 
     # Dervive coordinates of the grid square bounding box
-    x, y = bng_to_xy(bng_ref, "lower-left")
+    x, y = bng_to_xy(bng_ref, position="lower-left")
 
     # Derive parent BNGReference object from coordinates
     bng_ref = xy_to_bng(x, y, validated_resolution)

--- a/osbng/hierarchy.py
+++ b/osbng/hierarchy.py
@@ -37,7 +37,10 @@ def bng_to_children(bng_ref: BNGReference, *, resolution: int | str | None = Non
 
     Args:
         bng_ref (BNGReference): The BNGReference object to derive children from.
-        resolution (int | str | None): The resolution of the children BNGReference objects expressed either as a metre-based integer or as a string label. Defaults to None.
+
+    Kwargs:
+        resolution (int | str | None): The resolution of the children BNGReference objects expressed either as a
+            metre-based integer or as a string label. Defaults to None. Keyword only.
 
     Returns:
         list[BNGReference]: A list of BNGReference objects that are children of the input BNGReference object.
@@ -107,7 +110,10 @@ def bng_to_parent(bng_ref: BNGReference, *, resolution: int | str | None = None)
 
     Args:
         bng_ref (BNGReference): The BNGReference object to derive parent from.
-        resolution (int | str | None): The resolution of the parent BNGReference objects expressed either as a metre-based integer or as a string label. Defaults to None.
+
+    Kwargs:
+        resolution (int | str | None): The resolution of the parent BNGReference objects expressed either as a
+            metre-based integer or as a string label. Defaults to None. Keyword only.
 
     Returns:
         BNGReference: A BNGReference object that is the parent of the input BNGReference object.

--- a/osbng/indexing.py
+++ b/osbng/indexing.py
@@ -361,7 +361,7 @@ def xy_to_bng(easting: int | float, northing: int | float, resolution: int | str
 
 @_validate_bngreference
 def bng_to_xy(
-    bng_ref: BNGReference, position: str = "lower-left"
+    bng_ref: BNGReference, *, position: str = "lower-left"
 ) -> tuple[int | float, int | float]:
     """Returns the easting and northing coordinates given a BNG reference object, at a specified grid cell position.
 

--- a/osbng/indexing.py
+++ b/osbng/indexing.py
@@ -367,9 +367,7 @@ def bng_to_xy(
 
     Args:
         bng_ref (BNGReference): The BNG eference object.
-
-    Kwargs:
-        position (str): The grid cell position expressed as a string.
+        position (str, optional): The grid cell position expressed as a string.
                         One of: 'lower-left', 'upper-left', 'upper-right', 'lower-right', 'centre'.
                         Keyword only.
 

--- a/osbng/indexing.py
+++ b/osbng/indexing.py
@@ -379,13 +379,13 @@ def bng_to_xy(
         ValueError: If an invalid position provided.
 
     Example:
-        >>> bng_to_xy(BNGReference("SU"), "lower-left")
+        >>> bng_to_xy(BNGReference("SU"), position="lower-left")
         (400000, 100000)
-        >>> bng_to_xy(BNGReference("SU 3 1"), "lower-left")
+        >>> bng_to_xy(BNGReference("SU 3 1"), position="lower-left")
         (430000, 110000)
-        >>> bng_to_xy(BNGReference("SU 3 1 NE"), "centre")
+        >>> bng_to_xy(BNGReference("SU 3 1 NE"), position="centre")
         (437500, 117500)
-        >>> bng_to_xy(BNGReference("SU 37289 15541"), "centre)
+        >>> bng_to_xy(BNGReference("SU 37289 15541"), position="centre)
         (437289.5, 115541.5)
     """
     # validate position string
@@ -502,8 +502,8 @@ def bng_to_bbox(bng_ref: BNGReference) -> tuple[int, int, int, int]:
         (437289, 115541, 437290, 115542)
     """
     # Extract lower left and upper right coordinates of grid square
-    min_xy = bng_to_xy(bng_ref, "lower-left")
-    max_xy = bng_to_xy(bng_ref, "upper-right")
+    min_xy = bng_to_xy(bng_ref, position="lower-left")
+    max_xy = bng_to_xy(bng_ref, position="upper-right")
 
     return min_xy + max_xy
 

--- a/osbng/indexing.py
+++ b/osbng/indexing.py
@@ -367,8 +367,11 @@ def bng_to_xy(
 
     Args:
         bng_ref (BNGReference): The BNG eference object.
+
+    Kwargs:
         position (str): The grid cell position expressed as a string.
                         One of: 'lower-left', 'upper-left', 'upper-right', 'lower-right', 'centre'.
+                        Keyword only.
 
     Returns:
         tuple[int | float, int | float]: The easting and northing coordinates as a tuple.

--- a/osbng/indexing_gpd.py
+++ b/osbng/indexing_gpd.py
@@ -130,7 +130,7 @@ def gdf_to_bng_intersection_explode(
         # Extract the geometry from the specified geometry column
         geom = row[geometry_column]
         # Convert the geometry to BNGIndexedGeometry objects
-        bng_idx_geoms = geom_to_bng_intersection(geom, validated_resolution)
+        bng_idx_geoms = geom_to_bng_intersection(geom, resolution=validated_resolution)
         # Drop the geometry column from the original row
         orig_row = row.drop(geometry_column)
 

--- a/osbng/indexing_gpd.py
+++ b/osbng/indexing_gpd.py
@@ -130,7 +130,7 @@ def gdf_to_bng_intersection_explode(
         # Extract the geometry from the specified geometry column
         geom = row[geometry_column]
         # Convert the geometry to BNGIndexedGeometry objects
-        bng_idx_geoms = geom_to_bng_intersection(geom, resolution=validated_resolution)
+        bng_idx_geoms = geom_to_bng_intersection(geom, validated_resolution)
         # Drop the geometry column from the original row
         orig_row = row.drop(geometry_column)
 

--- a/osbng/traversal.py
+++ b/osbng/traversal.py
@@ -51,7 +51,7 @@ def _ring_or_disc(bng_ref: BNGReference, k: int, is_disc: bool, return_relations
     
     
     # Derive point location of root square
-    xc, yc = bng_to_xy(bng_ref, "centre")
+    xc, yc = bng_to_xy(bng_ref, position="centre")
 
     # Initialise list of ring BNG reference objects
     kring_refs = []
@@ -227,10 +227,10 @@ def bng_distance(bng_ref1: BNGReference, bng_ref2: BNGReference, *, edge_to_edge
             return 0.0
 
     # Derive the centroid of the first BNGReference object
-    centroid1 = bng_to_xy(bng_ref1, "centre")
+    centroid1 = bng_to_xy(bng_ref1, position="centre")
 
     # Derive the centroid of the second BNGReference object
-    centroid2 = bng_to_xy(bng_ref2, "centre")
+    centroid2 = bng_to_xy(bng_ref2, position="centre")
 
     # Note this must be a new if-else logic to the above special case, to catch cases where bng_ref1 and bng_ref2
     # do not share a resolution but are not parents
@@ -264,7 +264,7 @@ def bng_neighbours(bng_ref: BNGReference) -> list[BNGReference]:
     """
 
     # Get the centroid of the bng square
-    x, y = bng_to_xy(bng_ref, "centre")
+    x, y = bng_to_xy(bng_ref, position="centre")
     
     # Initialise a neighbours list
     neighbours_list = []

--- a/osbng/traversal.py
+++ b/osbng/traversal.py
@@ -137,9 +137,7 @@ def bng_kdisc(bng_ref: BNGReference, k: int, *, return_relations: bool = False) 
     Args:
         bng_ref (BNGReference): A BNGReference object.
         k (int): Grid distance in units of grid squares.
-
-    Kwargs:
-        return_relations (bool): If True, returns a list of (BNGReference, dx, dy) tuples where dx, dy are integer offsets in 
+        return_relations (bool, optional): If True, returns a list of (BNGReference, dx, dy) tuples where dx, dy are integer offsets in 
             grid units.  If False (default), returns a list of BNGReference objects.  Keyword only.
 
     Returns:

--- a/osbng/traversal.py
+++ b/osbng/traversal.py
@@ -88,7 +88,7 @@ def _ring_or_disc(bng_ref: BNGReference, k: int, is_disc: bool, return_relations
     return kring_refs
 
 @_validate_bngreference
-def bng_kring(bng_ref: BNGReference, k: int, return_relations: bool = False) -> list[BNGReference]:
+def bng_kring(bng_ref: BNGReference, k: int, *, return_relations: bool = False) -> list[BNGReference]:
     """Returns a list of BNG reference objects representing a hollow ring around a given BNG reference object
     at a grid distance k.
 
@@ -100,7 +100,7 @@ def bng_kring(bng_ref: BNGReference, k: int, return_relations: bool = False) -> 
 
     Kwargs:
         return_relations (bool): If True, returns a list of (BNGReference, dx, dy) tuples where dx, dy are integer offsets in 
-            grid units.  If False (default), returns a list of BNGReference objects.
+            grid units.  If False (default), returns a list of BNGReference objects.  Keyword only.
 
     Returns:
         list[BNGReference]: All BNGReference objects representing squares in a square ring of radius k.
@@ -130,7 +130,7 @@ def bng_kring(bng_ref: BNGReference, k: int, return_relations: bool = False) -> 
     return _ring_or_disc(bng_ref, k, False, return_relations)
 
 @_validate_bngreference
-def bng_kdisc(bng_ref: BNGReference, k: int, return_relations: bool = False) -> list[BNGReference]:
+def bng_kdisc(bng_ref: BNGReference, k: int, *, return_relations: bool = False) -> list[BNGReference]:
     """Returns a list of BNG reference objects representing a filled disc around a given BNG reference object
     up to a grid distance k, including the given central BNG reference object.
 
@@ -142,7 +142,7 @@ def bng_kdisc(bng_ref: BNGReference, k: int, return_relations: bool = False) -> 
 
     Kwargs:
         return_relations (bool): If True, returns a list of (BNGReference, dx, dy) tuples where dx, dy are integer offsets in 
-            grid units.  If False (default), returns a list of BNGReference objects.
+            grid units.  If False (default), returns a list of BNGReference objects.  Keyword only.
 
     Returns:
         list[BNGReference]: All BNGReference objects representing grid squares in a square of radius k.
@@ -175,7 +175,7 @@ def bng_kdisc(bng_ref: BNGReference, k: int, return_relations: bool = False) -> 
 
 
 @_validate_bngreference_pair
-def bng_distance(bng_ref1: BNGReference, bng_ref2: BNGReference, edge_to_edge: bool = False) -> float:
+def bng_distance(bng_ref1: BNGReference, bng_ref2: BNGReference, *, edge_to_edge: bool = False) -> float:
     """Returns the euclidean distance between the centroids of two BNGReference objects.
     
     Note that the two BNGReference objects do not necessarily need to share a common resolution.
@@ -189,6 +189,7 @@ def bng_distance(bng_ref1: BNGReference, bng_ref2: BNGReference, edge_to_edge: b
     Kwargs:
         edge_to_edge (bool): If False (default), distance will be centroid-to-centroid distance.
             If True, distance will be the shortest distance between any point in the grid squares.
+            Keyword only.
 
     Returns:
         float: The euclidean distance between the centroids of the two BNGReference objects.

--- a/osbng/traversal.py
+++ b/osbng/traversal.py
@@ -97,9 +97,7 @@ def bng_kring(bng_ref: BNGReference, k: int, *, return_relations: bool = False) 
     Args:
         bng_ref (BNGReference): A BNGReference object.
         k (int): Grid distance in units of grid squares.
-
-    Kwargs:
-        return_relations (bool): If True, returns a list of (BNGReference, dx, dy) tuples where dx, dy are integer offsets in 
+        return_relations (bool, optional): If True, returns a list of (BNGReference, dx, dy) tuples where dx, dy are integer offsets in 
             grid units.  If False (default), returns a list of BNGReference objects.  Keyword only.
 
     Returns:
@@ -185,9 +183,7 @@ def bng_distance(bng_ref1: BNGReference, bng_ref2: BNGReference, *, edge_to_edge
     Args:
         bng_ref1 (BNGReference): A BNGReference object.
         bng_ref2 (BNGReference): A BNGReference object.
-
-    Kwargs:
-        edge_to_edge (bool): If False (default), distance will be centroid-to-centroid distance.
+        edge_to_edge (bool, optional): If False (default), distance will be centroid-to-centroid distance.
             If True, distance will be the shortest distance between any point in the grid squares.
             Keyword only.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "osbng"
-version = "0.2.0"
+version = "0.2.1"
 description = "A Python package supporting geospatial grid indexing and interaction with Ordnance Survey's British National Grid index system"
 readme = "README.md"
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "osbng"
-version = "0.2.1"
+version = "0.3.0"
 description = "A Python package supporting geospatial grid indexing and interaction with Ordnance Survey's British National Grid index system"
 readme = "README.md"
 license = "MIT"

--- a/tests/test_hierarchy.py
+++ b/tests/test_hierarchy.py
@@ -66,11 +66,11 @@ def test_bng_to_children(test_case: BNGToChildrenTestCase):
         exception_class = _EXCEPTION_MAP[exception_name]
         # Assert that the test case raises the expected exception and message
         with pytest.raises(exception_class, match=message):
-            bng_to_children(BNGReference(bng_ref_string), resolution)
+            bng_to_children(BNGReference(bng_ref_string), resolution=resolution)
 
     else:
         # Return a list of child BNGReference objects
-        bng_refs = bng_to_children(BNGReference(bng_ref_string), resolution)
+        bng_refs = bng_to_children(BNGReference(bng_ref_string), resolution=resolution)
         # Sort lists to account for order differences
         bng_ref_strings = [bng_ref.bng_ref_formatted for bng_ref in bng_refs]
         # Assert that the function returns the expected result
@@ -122,10 +122,10 @@ def test_bng_to_parent(test_case: BNGToParentTestCase):
         exception_class = _EXCEPTION_MAP[exception_name]
         # Assert that the test case raises the expected exception and message
         with pytest.raises(exception_class, match=message):
-            bng_to_parent(BNGReference(bng_ref_string), resolution)
+            bng_to_parent(BNGReference(bng_ref_string), resolution=resolution)
 
     else:
         # Return the parent BNGReference object
-        bng_ref = bng_to_parent(BNGReference(bng_ref_string), resolution)
+        bng_ref = bng_to_parent(BNGReference(bng_ref_string), resolution=resolution)
         # Assert that the function returns the expected result
         assert bng_ref.bng_ref_formatted == test_case["expected"]["bng_ref_formatted"]

--- a/tests/test_indexing.py
+++ b/tests/test_indexing.py
@@ -349,7 +349,7 @@ def test_bng_to_xy(test_case: BNGToXYTestCase):
     bng_ref = BNGReference(bng_ref_string)
 
     # Assert that the function returns the expected result
-    assert bng_to_xy(bng_ref, position) == expected
+    assert bng_to_xy(bng_ref, position=position) == expected
 
 
 class BNGToBBOXTestCase(TypedDict):


### PR DESCRIPTION
This PR closes #18.

For some functions, it would be beneficial to force a user to explicitly specify a keyword argument, rather than using as a positional argument.  This PR forces such behaviour for the following functions and kwargs:
- `indexing.bng_to_xy`: `position` becomes a keyword-only argument
- `hierarchy.bng_to_children`: `resolution` becomes a keyword-only argument
- `hierarchy.bng_to_parent`: `resolution` becomes a keyword-only argument
- `traversal.bng_kring`: `return_relations` becomes a keyword-only argument
- `traversal.bng_kdisc`: `return_relations` becomes a keyword-only argument
- `traversal.bng_distance`: `edge_to_edge` becomes a keyword-only argument

This PR also bumps the package version number to 0.2.1.