### PR TITLE
Use a single flexible BNGReference-validating decorator

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -40,7 +40,7 @@ keywords:
   - british national grid
   - ordnance survey grid
 license: MIT
-version: 0.3.0
+version: 0.3.1
 date-released: 2025-06-25
 preferred-citation:
   type: software
@@ -50,5 +50,5 @@ preferred-citation:
   institution:
     name: Ordnance Survey Ltd
   year: '2025'
-  version: 0.2.0
+  version: 0.3.1
   repository-code: https://github.com/OrdnanceSurvey/osbng-py

--- a/osbng/__init__.py
+++ b/osbng/__init__.py
@@ -20,4 +20,4 @@ __all__ = [
     "geom_to_bng",
     "geom_to_bng_intersection",
 ]
-__version__ = "0.3.0"
+__version__ = "0.3.1"

--- a/osbng/bng_reference.py
+++ b/osbng/bng_reference.py
@@ -698,9 +698,6 @@ def _validate_bngreferences(func):
         # Create a dictionary of name:parameter pairs from the function signature
         signature_params_dict = dict(inspect.signature(func).parameters)
 
-        # Initialise a dictionary of name:(value, expected type) pairs
-        arg_expected_types_dict = {}
-
         # Function args are provided as a list
         for arg_num, arg_val in enumerate(args):
 
@@ -710,8 +707,11 @@ def _validate_bngreferences(func):
             # Extract expected type from function signature
             expected_type = list(signature_params_dict.values())[arg_num].annotation
 
-            # Append arg to name:(value, expected type) dict
-            arg_expected_types_dict[arg_name] = (arg_val, expected_type)
+            # If a BNGReference is expected and the arg value is not a BNGReference, raise an error
+            if (expected_type == BNGReference) and not isinstance(arg_val, BNGReference):
+                raise TypeError(
+                    f"A BNGReference object must be provided as the {arg_name} argument."
+                )
 
         # Function kwargs are provided as a name:value dict
         for kwarg_name, kwarg_val in kwargs.items():
@@ -719,17 +719,12 @@ def _validate_bngreferences(func):
             # Extract expected type from function signature
             expected_type = signature_params_dict[kwarg_name].annotation
 
-            # Append kwarg to name:(value, expected type) dict
-            arg_expected_types_dict[kwarg_name] = (kwarg_val, expected_type)
-
-        # Iterate through all args/kwargs to and check BNGReference
-        for arg_name, (arg_val, expected_type) in arg_expected_types_dict.items():
-            # If there's not a BNGReference when expected, raise an error
-            if (expected_type == BNGReference) and not isinstance(arg_val, BNGReference):
+            # If a BNGReference is expected and the kwarg value is not a BNGReference, raise an error
+            if (expected_type == BNGReference) and not isinstance(kwarg_val, BNGReference):
                 raise TypeError(
-                    f"A BNGReference object must be provided as {arg_name}."
+                    f"A BNGReference object must be provided as the {arg_name} keyword argument."
                 )
             
-            return func(*args, **kwargs)
+        return func(*args, **kwargs)
 
     return wrapper

--- a/osbng/bng_reference.py
+++ b/osbng/bng_reference.py
@@ -724,6 +724,7 @@ def _validate_bngreferences(func):
 
         # Iterate through all args/kwargs to and check BNGReference
         for arg_name, (arg_val, expected_type) in arg_expected_types_dict.items():
+            # If there's not a BNGReference when expected, raise an error
             if (expected_type == BNGReference) and not isinstance(arg_val, BNGReference):
                 raise TypeError(
                     f"A BNGReference object must be provided as {arg_name}."

--- a/osbng/bng_reference.py
+++ b/osbng/bng_reference.py
@@ -82,6 +82,7 @@ increasing detail, allowing for variable accuracy depending on the geospatial ap
 survey measurements.
 """
 
+import inspect
 import re
 from functools import wraps
 from shapely.geometry import Polygon, mapping
@@ -687,6 +688,50 @@ class BNGReference:
 
         return _bng_dwithin(self, d)
 
+
+def _validate_bngreference_single(func):
+    """One decorator to rule them all"""
+
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+    
+        # Create a dictionary of name:parameter pairs from the function signature
+        signature_params_dict = dict(inspect.signature(func).parameters)
+
+        # Initialise a dictionary of name:(value, expected type) pairs
+        arg_expected_types_dict = {}
+
+        # Function args are provided as a list
+        for arg_num, arg_val in enumerate(args):
+
+            # Extract arg name from function signature
+            arg_name = list(signature_params_dict.values())[arg_num].name
+
+            # Extract expected type from function signature
+            expected_type = list(signature_params_dict.values())[arg_num].annotation
+
+            # Append arg to name:(value, expected type) dict
+            arg_expected_types_dict[arg_name] = (arg_val, expected_type)
+
+        # Function kwargs are provided as a name:value dict
+        for kwarg_name, kwarg_val in kwargs.items():
+            
+            # Extract expected type from function signature
+            expected_type = signature_params_dict[kwarg_name].annotation
+
+            # Append kwarg to name:(value, expected type) dict
+            arg_expected_types_dict[kwarg_name] = (kwarg_val, expected_type)
+
+        # Iterate through all args/kwargs to and check BNGReference
+        for arg_name, (arg_val, expected_type) in arg_expected_types_dict.items():
+            if ("BNGReference" in expected_type) and not isinstance(arg_val, BNGReference):
+                raise TypeError(
+                    f"A BNGReference object must be provided as {arg_name}."
+                )
+            
+            return func(*args, **kwargs)
+
+    return wrapper
 
 def _validate_bngreference(func):
     """Decorator to validate that a BNGReference object is passed as either the first positional argument or as the bng_ref keyword argument."""

--- a/osbng/bng_reference.py
+++ b/osbng/bng_reference.py
@@ -689,8 +689,8 @@ class BNGReference:
         return _bng_dwithin(self, d)
 
 
-def _validate_bngreference_single(func):
-    """One decorator to rule them all"""
+def _validate_bngreferences(func):
+    """Decorator to validate that a BNGReference object is passed as an arg or kwarg when expected."""
 
     @wraps(func)
     def wrapper(*args, **kwargs):
@@ -724,54 +724,11 @@ def _validate_bngreference_single(func):
 
         # Iterate through all args/kwargs to and check BNGReference
         for arg_name, (arg_val, expected_type) in arg_expected_types_dict.items():
-            if ("BNGReference" in expected_type) and not isinstance(arg_val, BNGReference):
+            if (expected_type == BNGReference) and not isinstance(arg_val, BNGReference):
                 raise TypeError(
                     f"A BNGReference object must be provided as {arg_name}."
                 )
             
             return func(*args, **kwargs)
-
-    return wrapper
-
-def _validate_bngreference(func):
-    """Decorator to validate that a BNGReference object is passed as either the first positional argument or as the bng_ref keyword argument."""
-
-    @wraps(func)
-    def wrapper(*args, **kwargs):
-        # Validate first positional argument
-        if args and isinstance(args[0], BNGReference):
-            return func(*args, **kwargs)
-
-        # Validate bng_ref keyword argument
-        if "bng_ref" in kwargs and isinstance(kwargs["bng_ref"], BNGReference):
-            return func(*args, **kwargs)
-
-        # Raise TypeError if neither condition is met
-        raise TypeError(
-            "A BNGReference object must be provided as the first positional argument or as the bng_ref keyword argument."
-        )
-
-    return wrapper
-
-
-def _validate_bngreference_pair(func):
-    """Decorator to validate that two BNGReference objects are passed as either the first two positional arguments or as the bng_ref1 and bng_ref2 keyword arguments."""
-
-    @wraps(func)
-    def wrapper(*args, **kwargs):
-        # Validate first two positional arguments
-        if len(args) >= 2 and isinstance(args[0], BNGReference) and isinstance(args[1], BNGReference):
-            return func(*args, **kwargs)
-
-        # Validate bng_ref1 and bng_ref2 keyword arguments
-        if (
-            "bng_ref1" in kwargs and isinstance(kwargs["bng_ref1"], BNGReference) and
-            "bng_ref2" in kwargs and isinstance(kwargs["bng_ref2"], BNGReference)
-        ):
-            return func(*args, **kwargs)
-
-        raise TypeError(
-            "Two BNGReference objects must be provided as the first two positional arguments or as the bng_ref1 and bng_ref2 keyword arguments."
-        )
 
     return wrapper

--- a/osbng/hierarchy.py
+++ b/osbng/hierarchy.py
@@ -17,7 +17,7 @@ Supported Resolutions:
       'resolution' module.
 """
 
-from osbng.bng_reference import BNGReference, _validate_bngreference
+from osbng.bng_reference import BNGReference, _validate_bngreferences
 from osbng.errors import BNGHierarchyError
 from osbng.indexing import _validate_and_normalise_bng_resolution, xy_to_bng, bng_to_xy, bbox_to_bng
 from osbng.resolution import BNG_RESOLUTIONS
@@ -25,7 +25,7 @@ from osbng.resolution import BNG_RESOLUTIONS
 __all__ = ["bng_to_children", "bng_to_parent"]
 
 
-@_validate_bngreference
+@_validate_bngreferences
 def bng_to_children(bng_ref: BNGReference, *, resolution: int | str | None = None) -> list[BNGReference]:
     """Returns a list of BNGReference objects that are children of the input BNGReference object.
 
@@ -96,7 +96,7 @@ def bng_to_children(bng_ref: BNGReference, *, resolution: int | str | None = Non
     return bng_refs
 
 
-@_validate_bngreference
+@_validate_bngreferences
 def bng_to_parent(bng_ref: BNGReference, *, resolution: int | str | None = None) -> BNGReference:
     """Returns a BNGReference object that is the parent of the input BNGReference object.
 

--- a/osbng/indexing.py
+++ b/osbng/indexing.py
@@ -31,7 +31,7 @@ import numpy as np
 from shapely import box, contains, Geometry, intersection, intersects, prepare
 from shapely.geometry import Polygon
 
-from osbng.bng_reference import _PATTERN, _validate_bngreference, BNGReference
+from osbng.bng_reference import _PATTERN, _validate_bngreferences, BNGReference
 from osbng.errors import BNGExtentError, BNGResolutionError
 from osbng.resolution import BNG_RESOLUTIONS
 
@@ -359,7 +359,7 @@ def xy_to_bng(easting: int | float, northing: int | float, resolution: int | str
         return BNGReference(prefix)
 
 
-@_validate_bngreference
+@_validate_bngreferences
 def bng_to_xy(
     bng_ref: BNGReference, *, position: str = "lower-left"
 ) -> tuple[int | float, int | float]:
@@ -479,7 +479,7 @@ def bng_to_xy(
         return easting, northing
 
 
-@_validate_bngreference
+@_validate_bngreferences
 def bng_to_bbox(bng_ref: BNGReference) -> tuple[int, int, int, int]:
     """Returns grid square bounding box coordinates given a BNGReference object.
 
@@ -509,7 +509,7 @@ def bng_to_bbox(bng_ref: BNGReference) -> tuple[int, int, int, int]:
     return min_xy + max_xy
 
 
-@_validate_bngreference
+@_validate_bngreferences
 def bng_to_grid_geom(bng_ref: BNGReference) -> Polygon:
     """Returns a grid square as a Shapely Polygon given a BNG Reference object.
 

--- a/osbng/traversal.py
+++ b/osbng/traversal.py
@@ -13,7 +13,7 @@ import warnings
 
 from osbng.hierarchy import bng_to_parent
 from osbng.indexing import bng_to_xy, xy_to_bng
-from osbng.bng_reference import BNGReference, _validate_bngreference, _validate_bngreference_pair
+from osbng.bng_reference import BNGReference, _validate_bngreferences
 from osbng.errors import BNGExtentError, BNGNeighbourError
 
 __all__ = [
@@ -87,7 +87,7 @@ def _ring_or_disc(bng_ref: BNGReference, k: int, is_disc: bool, return_relations
 
     return kring_refs
 
-@_validate_bngreference
+@_validate_bngreferences
 def bng_kring(bng_ref: BNGReference, k: int, *, return_relations: bool = False) -> list[BNGReference]:
     """Returns a list of BNG reference objects representing a hollow ring around a given BNG reference object
     at a grid distance k.
@@ -127,7 +127,7 @@ def bng_kring(bng_ref: BNGReference, k: int, *, return_relations: bool = False) 
 
     return _ring_or_disc(bng_ref, k, False, return_relations)
 
-@_validate_bngreference
+@_validate_bngreferences
 def bng_kdisc(bng_ref: BNGReference, k: int, *, return_relations: bool = False) -> list[BNGReference]:
     """Returns a list of BNG reference objects representing a filled disc around a given BNG reference object
     up to a grid distance k, including the given central BNG reference object.
@@ -170,7 +170,7 @@ def bng_kdisc(bng_ref: BNGReference, k: int, *, return_relations: bool = False) 
     return _ring_or_disc(bng_ref, k, True, return_relations)
 
 
-@_validate_bngreference_pair
+@_validate_bngreferences
 def bng_distance(bng_ref1: BNGReference, bng_ref2: BNGReference, *, edge_to_edge: bool = False) -> float:
     """Returns the euclidean distance between the centroids of two BNGReference objects.
     
@@ -241,7 +241,7 @@ def bng_distance(bng_ref1: BNGReference, bng_ref2: BNGReference, *, edge_to_edge
     return float(np.sqrt(dx**2 + dy**2))
 
 
-@_validate_bngreference
+@_validate_bngreferences
 def bng_neighbours(bng_ref: BNGReference) -> list[BNGReference]:
     """Returns a list of BNGReference objects representing the four neighbouring grid squares
     sharing an edge with the input BNGReference.
@@ -290,7 +290,7 @@ def bng_neighbours(bng_ref: BNGReference) -> list[BNGReference]:
 
     return neighbours_list
 
-@_validate_bngreference_pair
+@_validate_bngreferences
 def bng_is_neighbour(bng_ref1: BNGReference, bng_ref2: BNGReference) -> bool:
     """Returns True if the two BNGReference objects are neighbours, otherwise False.
     Neighbours are defined as grid squares that share an edge with the first BNGReference object.
@@ -326,7 +326,7 @@ def bng_is_neighbour(bng_ref1: BNGReference, bng_ref2: BNGReference) -> bool:
         return bng_ref2 in bng_neighbours(bng_ref1)
     
 
-@_validate_bngreference
+@_validate_bngreferences
 def bng_dwithin(bng_ref: BNGReference, d: int | float) -> list[BNGReference]:
     """Returns a list of BNG reference objects around a given BNG reference object within an absolute distance d.
     All squares will be returned for which any part of its boundary is within distance d of any part of

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "osbng"
-version = "0.3.0"
+version = "0.3.1"
 description = "A Python package supporting geospatial grid indexing and interaction with Ordnance Survey's British National Grid index system"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
This PR resolves #25 by replacing the `_validate_bngreference` and `_validate_bngreference_pair` decorator functions with a single `_validate_bngreferences` decorator.

The new decorator checks that all `args` and `kwargs` are of type `BNGReference` when expected.  The new decorator is therefore more flexible and extendable, in that it can be used for validating any future functions with any number of BNGReference arguments or keyword arguments.

This PR also bumps the version number to `0.3.1`