### PR TITLE
Module linting and formatting using Ruff: __init__.py, bng_reference.py, hierarchy.py, resolution.py, traversal.py, test_bng_reference.py, test_hierarchy.py, test_traversal.py

### DIFF
--- a/osbng/__init__.py
+++ b/osbng/__init__.py
@@ -1,7 +1,12 @@
-"""A Python package supporting Ordnance Survey's British National Grid index system.
+"""Geospatial grid indexing and interaction with the British National Grid.
 
-This package enables the use of the BNG index system for geospatial grid indexing and
-other interactions.
+Offers a streamlined programmatic interface to Ordnance Survey's British National Grid
+(BNG) index system, enabling efficient spatial indexing and analysis based on grid
+references. It supports a range of geospatial applications, including statistical
+aggregation, data visualisation, and interoperability across datasets. Designed for
+developers and analysts working with geospatial data in Great Britain, osbng simplifies
+integration with geospatial workflows and provides intuitive tools for exploring the
+structure and logic of the BNG system.
 """
 
 from osbng.bng_reference import BNGReference

--- a/osbng/__init__.py
+++ b/osbng/__init__.py
@@ -1,4 +1,8 @@
-"""A Python package supporting geospatial grid indexing and interaction with Ordnance Survey's British National Grid index system."""
+"""A Python package supporting Ordnance Survey's British National Grid index system.
+
+This package enables the use of the BNG index system for geospatial grid indexing and
+other interactions.
+"""
 
 from osbng.bng_reference import BNGReference
 from osbng.grids import *

--- a/osbng/bng_reference.py
+++ b/osbng/bng_reference.py
@@ -1,36 +1,40 @@
-"""Provides functionality to parse, create and manipulate British National Grid (BNG) references via a custom BNGReference object.
+"""Provides functionality to manipulate British National Grid (BNG) references.
 
 BNGReference Object
 ------------------------
 
-The BNG index system uses BNG references, also known more simply as grid or tile references, to identify and index locations across
-Great Britain (GB) into grid squares at various resolutions.
+The BNG index system uses BNG references, also known more simply as grid or tile
+references, to identify and index locations across Great Britain (GB) into grid squares
+at various resolutions.
 
-The BNGReference object is a custom class that encapsulates a BNG reference string, providing properties and methods to access
-and manipulate the reference.
+The BNGReference object is a custom class that encapsulates a BNG reference string,
+providing properties and methods to access and manipulate the reference.
 
 British National Grid Index System
 ------------------------
 
-The Ordnance Survey (OS) BNG index system, also known as the OS National Grid, is a rectangular
-Cartesian 700 x 1300km grid system based upon the transverse Mercator projection. In the BNG, locations
-are specified using coordinates, eastings (x) and northings (y), measured in meters from a defined
-origin point (0, 0) southwest of the Isles of Scilly off the coast of Cornwall, England. Values increase
-to the northeast, covering all of mainland GB and surrounding islands.
+The Ordnance Survey (OS) BNG index system, also known as the OS National Grid, is a
+rectangular Cartesian 700 x 1300km grid system based upon the transverse Mercator
+projection. In the BNG, locations are specified using coordinates, eastings (x) and
+northings (y), measured in meters from a defined origin point (0, 0) southwest of the
+Isles of Scilly off the coast of Cornwall, England. Values increase to the northeast,
+covering all of mainland GB and surrounding islands.
 
-The BNG is structured using a hierarchical system of grid squares at various resolutions. At its highest level,
-the grid divides GB into 100 km by 100 km squares, each identified by a two-letter code. Successive levels
-of resolution further subdivide the grid squares into finer detail, down to individual 1-meter squares.
+The BNG is structured using a hierarchical system of grid squares at various
+resolutions. At its highest level, the grid divides GB into 100 km by 100 km squares,
+each identified by a two-letter code. Successive levels of resolution further subdivide
+the grid squares into finer detail, down to individual 1-meter squares.
 
 BNG Reference Structure
 ------------------------
 
-Each BNG reference string consists of a series of alphanumeric characters that encode the easting and northing at
-a given resolution.
+Each BNG reference string consists of a series of alphanumeric characters that encode
+the easting and northing at a given resolution.
 
-A BNG reference includes a 2-letter prefix that identifies the 100 km grid square. This is followed by an
-easting and northing value, and optionally, a suffix indicating an ordinal (intercardinal) direction (NE, SE, SW, NW).
-These suffixes represent a quadtree subdivision of the grid at the 'standard' resolutions (100km, 10km, 1km, 100m, and 10m),
+A BNG reference includes a 2-letter prefix that identifies the 100 km grid square. This
+is followed by an easting and northing value, and optionally, a suffix indicating an
+ordinal (intercardinal) direction (NE, SE, SW, NW). These suffixes represent a quadtree
+subdivision of the grid at the 'standard' resolutions (100km, 10km, 1km, 100m, and 10m),
 with each direction indicating a specific quadrant.
 
 <prefix><easting value><northing value><suffix>
@@ -38,14 +42,15 @@ with each direction indicating a specific quadrant.
 There are two exceptions to this structure:
 
 1.  At the 100km resolution, a BNG reference consists only of the prefix.
-2.  At the 50km resolution, a BNG reference includes the prefix and the ordinal direction suffix but does not include easting
-or northing components.
+2.  At the 50km resolution, a BNG reference includes the prefix and the ordinal
+    direction suffix but does not include easting or northing components.
 
 A BNG reference can be expressed at different scales, as follows:
 
 1.  100km: Identified by a two-letter code (e.g. 'TQ').
-2.  50km: Subdivides the 100 km grid into four quadrants. The grid reference adds an ordinal direction suffix (NE, NW, SE, SW)
-    to indicate the quadrant within the 100 km square (e.g. 'TQ SW').
+2.  50km: Subdivides the 100 km grid into four quadrants. The grid reference adds an
+    ordinal direction suffix (NE, NW, SE, SW) to indicate the quadrant within the 100 km
+    square (e.g. 'TQ SW').
 3.  10km: Adds one-digit easting and northing values (e.g. 'TQ 2 3').
 4.  5km: Subdivides the 10 km square adding an ordinal suffix (e.g. 'TQ 53 SW').
 5.  1km: Adds two-digit easting and northing values (e.g. 'TQ 23 34').
@@ -59,34 +64,39 @@ A BNG reference can be expressed at different scales, as follows:
 BNG Reference Formatting
 ------------------------
 
-BNG reference strings passed to a BNGReference object must adhere to the following format:
+BNG reference strings passed to a BNGReference object must adhere to the following
+format:
 
-- Whitespace may or may not separate the components of the reference (i.e. between the two-letter 100km grid square prefix, easting,
-  northing, and ordinal suffix).
+- Whitespace may or may not separate the components of the reference (i.e. between the
+    two-letter 100km grid square prefix, easting, northing, and ordinal suffix).
 - If whitespace is present, it should be a single space character.
 - Whitespace can be inconsistently used between components of the reference.
-- The two-letter 100 km grid square prefixes and ordinal direction suffixes (NE, SE, SW, NW) should be capitalised.
+- The two-letter 100 km grid square prefixes and ordinal direction suffixes
+    (NE, SE, SW, NW) should be capitalised.
 
 EPSG:27700 (OSGB36 / British National Grid)
 ------------------------
 
-The BNG system is a practical application of the EPSG:27700 (OSGB36 / British National Grid) coordinate reference system
-(https://epsg.io/27700) which provides the geodetic framework that defines how locations defined by easting and northing coordinates
-and encoded as BNG references (e.g. 'ST 569 714') are projected to the grid.
+The BNG system is a practical application of the EPSG:27700 (OSGB36 / British National
+Grid) coordinate reference system (https://epsg.io/27700) which provides the geodetic
+framework that defines how locations defined by easting and northing coordinates and
+encoded as BNG references (e.g. 'ST 569 714') are projected to the grid.
 
 BNG Reference Application
 ------------------------
 
-The BNG index system is widely used by the geospatial community across GB. At each resolution, a given location can be identified with
-increasing detail, allowing for variable accuracy depending on the geospatial application, from small-scale mapping to precise
-survey measurements.
+The BNG index system is widely used by the geospatial community across GB. At each
+resolution, a given location can be identified with increasing detail, allowing for
+variable accuracy depending on the geospatial application, from small-scale mapping to
+precise survey measurements.
 """
 
 import inspect
 import re
 from functools import wraps
+from typing import Callable, Union
+
 from shapely.geometry import Polygon, mapping
-from typing import Union
 
 from osbng.errors import BNGReferenceError
 from osbng.resolution import BNG_RESOLUTIONS
@@ -190,7 +200,8 @@ def _get_bng_resolution_metres(bng_ref_string: str) -> int:
 def _get_bng_resolution_label(bng_ref_string: str) -> str:
     """Gets the resolution of a BNG reference expressed as a descriptive string.
 
-    The resolution is returned in a human-readable format, such as '10km', '50km', '5km' etc.
+    The resolution is returned in a human-readable format, such as '10km', '50km', '5km'
+    etc.
 
     Args:
         bng_ref_string (str): The BNG reference string.
@@ -256,10 +267,11 @@ def _format_bng_ref_string(bng_ref_string: str) -> str:
 class BNGReference:
     """A custom object for handling British National Grid (BNG) references.
 
-    Converts a BNG reference string into a BNGReference object, ensuring type consistency
-    across the package. All functions accepteding or returning BNG references enforce the use of this class.
-    These functions are available both as instance methods of the BNGReference object and as standalone functions,
-    providing users with the flexibility to either:
+    Converts a BNG reference string into a BNGReference object, ensuring type
+    consistency across the package. All functions accepteding or returning BNG
+    references enforce the use of this class. These functions are available both as
+    instance methods of the BNGReference object and as standalone functions, providing
+    users with the flexibility to either:
 
     - Create a BNGReference object and pass it to a function.
     - Create a BNGReference object and use one of its instance methods.
@@ -269,17 +281,25 @@ class BNGReference:
 
     Properties:
         bng_ref_compact (str): The BNG reference with whitespace removed.
-        bng_ref_formatted (str): The pretty-formatted version of the BNG reference with single spaces between components.
+        bng_ref_formatted (str): The pretty-formatted version of the BNG reference with
+            single spaces between components.
         resolution_metres (int): The resolution of the BNG reference in meters.
-        resolution_label (str): The resolution of the BNG reference expressed as a descriptive string.
+        resolution_label (str): The resolution of the BNG reference expressed as a
+            descriptive string.
         __geo_interface__ (dict): A GeoJSON-like mapping for a BNGReference object.
 
     Methods:
-        bng_to_xy(position: str, optional) -> tuple[int | float, int | float]: Returns the easting and northing coordinates for the current BNGReference object.
-        bng_to_bbox() -> tuple[int, int, int, int]: Returns bounding box coordinates for the current BNGReference object.
-        bng_to_grid_geom() -> Polygon: Returns a grid square as a Shapely Polygon for the current BNGReference object.
-        bng_to_children(resolution: int | str | None, optional) -> list[BNGReference]: Returns a list of BNGReference objects that are children of the input BNGReference object.
-        bng_to_parent(resolution: int | str | None, optional) -> BNGReference: Returns a BNGReference object that is the parent of the input BNGReference object.
+        bng_to_xy(position: str, optional) -> tuple[int | float, int | float]: Returns
+            the easting and northing coordinates for the current BNGReference object.
+        bng_to_bbox() -> tuple[int, int, int, int]: Returns bounding box coordinates for
+            the current BNGReference object.
+        bng_to_grid_geom() -> Polygon: Returns a grid square as a Shapely Polygon for
+            the current BNGReference object.
+        bng_to_children(resolution: int | str | None, optional) -> list[BNGReference]:
+            Returns a list of BNGReference objects that are children of the input
+            BNGReference object.
+        bng_to_parent(resolution: int | str | None, optional) -> BNGReference: Returns a
+            BNGReference object that is the parent of the input BNGReference object.
 
     Raises:
         BNGReferenceError: If the BNG reference string is invalid.
@@ -303,6 +323,7 @@ class BNGReference:
     """
 
     def __init__(self, bng_ref_string: str):
+        """Initialise a BNGReference object."""
         # Validate the BNG reference string
         if not _validate_bng_ref_string(bng_ref_string):
             raise BNGReferenceError(f"Invalid BNG reference string: '{bng_ref_string}'")
@@ -317,7 +338,7 @@ class BNGReference:
 
     @property
     def bng_ref_formatted(self) -> str:
-        """Returns a pretty-formatted version of the BNG reference string with single spaces between components."""
+        """Returns a pretty-formatted version with single spaces between components."""
         return _format_bng_ref_string(self._bng_ref_compact)
 
     @property
@@ -334,8 +355,9 @@ class BNGReference:
     def __geo_interface__(self) -> dict[str, Union[str, dict]]:
         """Returns a GeoJSON-like mapping for a BNGReference object.
 
-        Implements the __geo_interface__ protocol. The returned data structure represents the
-        BNGReference object as a GeoJSON-like Feature."""
+        Implements the __geo_interface__ protocol. The returned data structure
+        represents the BNGReference object as a GeoJSON-like Feature.
+        """
         return {
             "type": "Feature",
             "properties": {
@@ -344,12 +366,25 @@ class BNGReference:
             "geometry": mapping(self.bng_to_grid_geom()),
         }
 
-    def __eq__(self, other):
+    def __eq__(self, other: object):
+        """Defined equality based on self.bng_ref_compact."""
         if isinstance(other, BNGReference):
             return self.bng_ref_compact == other.bng_ref_compact
         return False
 
-    def __lt__(self, other):
+    def __lt__(self, other: object):
+        """Defines ordering using resolution_metres and bng_ref_compact.
+        
+        For two BNGReference objects, ordering is done in the following order:
+        1. Rank by self.resolution_metres, where higher resolutions are ordered first.
+        2. Rank by self.bng_ref_compact alphabetically.
+
+        Example:
+            >>> BNGReference("SU") < BNGReference("SU1234")
+            True
+            >>> BNGReference("SU") < BNGReference("TU")
+            True
+        """
         if isinstance(other, BNGReference):
             return (-self.resolution_metres, self.bng_ref_compact) < (
                 -other.resolution_metres,
@@ -358,22 +393,27 @@ class BNGReference:
         return NotImplemented
 
     def __hash__(self):
+        """Uses self.bng_ref_compact for hashing."""
         return hash(self.bng_ref_compact)
 
     def __repr__(self):
-        return f"BNGReference(bng_ref_formatted={self.bng_ref_formatted}, resolution_label={self.resolution_label})"
+        """Prints in format showing self.bng_ref_formatted and self.resolution_label."""
+        return f"BNGReference(bng_ref_formatted={self.bng_ref_formatted}, "\
+            f"resolution_label={self.resolution_label})"
 
     def bng_to_xy(
         self, position: str = "lower-left"
     ) -> tuple[int | float, int | float]:
-        """Returns the easting and northing coordinates for the current BNGReference object, at a specified grid cell position.
+        """Returns the easting and northing for a specified grid cell position.
 
         Args:
             position (str): The grid cell position expressed as a string.
-                            One of: 'lower-left', 'upper-left', 'upper-right', 'lower-right', 'centre'.
+                            One of: 'lower-left', 'upper-left', 'upper-right',
+                            'lower-right', 'centre'.
 
         Returns:
-            tuple[int | float, int | float]: The easting and northing coordinates as a tuple.
+            tuple[int | float, int | float]: The easting and northing coordinates as a
+                tuple.
 
         Raises:
             ValueError: If invalid position provided.
@@ -396,7 +436,8 @@ class BNGReference:
         """Returns bounding box coordinates for the current BNGReference object.
 
         Returns:
-            tuple[int, int, int, int]: The bounding box coordinates (min x, min y, max x, max y) as a tuple.
+            tuple[int, int, int, int]: The bounding box coordinates
+                (min x, min y, max x, max y) as a tuple.
 
         Example:
             >>> BNGReference("SU").bng_to_bbox()
@@ -413,20 +454,24 @@ class BNGReference:
         return _bng_to_bbox(self)
 
     def bng_to_grid_geom(self) -> Polygon:
-        """Returns a grid square as a Shapely Polygon for the current BNGReference object.
+        """Returns the BNGReference object's grid square as a Shapely Polygon.
 
         Returns:
             Polygon: Grid square as Shapely Polygon object.
 
         Example:
             >>> BNGReference("SU").bng_to_grid_geom().wkt
-            'POLYGON ((500000 100000, 500000 200000, 400000 200000, 400000 100000, 500000 100000))'
+            'POLYGON ((500000 100000, 500000 200000, 400000 200000, 400000 100000,
+                500000 100000))'
             >>> BNGReference("SU 3 1").bng_to_grid_geom().wkt
-            'POLYGON ((440000 110000, 440000 120000, 430000 120000, 430000 110000, 440000 110000))'
+            'POLYGON ((440000 110000, 440000 120000, 430000 120000, 430000 110000,
+                440000 110000))'
             >>> BNGReference("SU 3 1 NE").bng_to_grid_geom().wkt
-            'POLYGON ((440000 115000, 440000 120000, 435000 120000, 435000 115000, 440000 115000))'
+            'POLYGON ((440000 115000, 440000 120000, 435000 120000, 435000 115000,
+                440000 115000))'
             >>> BNGReference("SU 37289 15541").bng_to_grid_geom().wkt
-            'POLYGON ((437290 115541, 437290 115542, 437289 115542, 437289 115541, 437290 115541))'
+            'POLYGON ((437290 115541, 437290 115542, 437289 115542, 437289 115541,
+                437290 115541))'
         """
         from osbng.indexing import bng_to_grid_geom as _bng_to_grid_geom
 
@@ -435,23 +480,28 @@ class BNGReference:
     def bng_to_children(
         self, resolution: int | str | None = None
     ) -> list["BNGReference"]:
-        """Returns a list of BNGReference objects that are children of the current BNGReference object.
+        """Returns the children of the current BNGReference object.
 
-        By default, the children of the BNGReference object is defined as the BNGReference objects in the
-        next resolution down from the input BNGReference resolution. For example, 100km -> 50km.
+        By default, the children of the BNGReference object is defined as the
+        BNGReference objects in the next resolution down from the input BNGReference
+        resolution. For example, 100km -> 50km.
 
-        Any valid resolution can be provided as the child resolution, provided it is less than the
-        resolution of the input BNGReference.
+        Any valid resolution can be provided as the child resolution, provided it is
+        less than the resolution of the input BNGReference.
 
         Args:
-            resolution (int | str | None, optional): The resolution of the children BNGReference objects. Defaults to None.
+            resolution (int | str | None, optional): The resolution of the children
+                BNGReference objects. Defaults to None.
 
         Returns:
-            list[BNGReference]: A list of BNGReference objects that are children of the current BNGReference object.
+            list[BNGReference]: A list of BNGReference objects that are children of the
+                current BNGReference object.
 
         Raises:
-            BNGHierarchyError: If the resolution of the current BNGReference object is 1m.
-            BNGHierarchyError: If the resolution is greater than or equal to the resolution of the current BNGReference object.
+            BNGHierarchyError: If the resolution of the current BNGReference object is
+                1m.
+            BNGHierarchyError: If the resolution is greater than or equal to the
+                resolution of the current BNGReference object.
             BNGResolutionError: If an invalid resolution is provided.
 
         Examples:
@@ -466,29 +516,33 @@ class BNGReference:
             BNGReference(bng_ref_formatted=SU 3 6 NW, resolution_label=5km),
             BNGReference(bng_ref_formatted=SU 3 6 NE, resolution_label=5km)]
         """
-
         from osbng.hierarchy import bng_to_children as _bng_to_children
 
         return _bng_to_children(self, resolution)
 
     def bng_to_parent(self, resolution: int | str | None = None) -> "BNGReference":
-        """Returns a BNGReference object that is the parent of the current BNGReference object.
+        """Returns the parent of the current BNGReference object.
 
-        By default, the parent of the BNGReference object is defined as the BNGReference in the next BNG
-        resolution up from the current BNGReference resolution. For example, 50km -> 100km.
+        By default, the parent of the BNGReference object is defined as the
+        BNGReference in the next BNG resolution up from the current BNGReference
+        resolution. For example, 50km -> 100km.
 
-        Any valid resolution can be provided as the parent resolution, provided it is greater than the
-        resolution of the current BNGReference.
+        Any valid resolution can be provided as the parent resolution, provided it is
+        greater than the resolution of the current BNGReference.
 
         Args:
-            resolution (int | str | None, optional): The resolution of the parent BNGReference. Defaults to None.
+            resolution (int | str | None, optional): The resolution of the parent
+                BNGReference. Defaults to None.
 
         Returns:
-            BNGReference: A BNGReference object that is the parent of the current BNGReference object.
+            BNGReference: A BNGReference object that is the parent of the current
+                BNGReference object.
 
         Raises:
-            BNGHierarchyError: If the resolution of the current BNGReference object is 100km.
-            BNGHierarchyError: If the resolution is less than or equal to the resolution of the current BNGReference object.
+            BNGHierarchyError: If the resolution of the current BNGReference object is
+                100km.
+            BNGHierarchyError: If the resolution is less than or equal to the resolution
+                of the current BNGReference object.
             BNGResolutionError: If an invalid resolution is provided.
 
         Examples:
@@ -500,71 +554,92 @@ class BNGReference:
             BNGReference(bng_ref_formatted=SU 3 5, resolution_label=10km)
 
         """
-
         from osbng.hierarchy import bng_to_parent as _bng_to_parent
 
         return _bng_to_parent(self, resolution)
 
     def bng_kring(self, k: int, return_relations: bool = False) -> list["BNGReference"]:
-        """Returns a list of BNG reference objects representing a hollow ring around the current BNG reference object
-        at a grid distance k.
+        """Returns a hollow ring around the current BNGReference object.
 
-        Returned BNG reference objects are ordered North to South then West to East, therefore not in ring order.
+        Returns all BNGReference objects at a grid distance k.
+
+        Returned BNG reference objects are ordered North to South then West to East,
+        therefore not in ring order.
 
         Args:
             k (int): Grid distance in units of grid squares.
-            return_relations (bool, optional): If True, returns a list of (BNGReference, dx, dy) tuples where dx, dy are integer offsets in
-                grid units.  If False (default), returns a list of BNGReference objects.
+            return_relations (bool, optional): If True, returns a list of
+                (BNGReference, dx, dy) tuples where dx, dy are integer offsets in grid
+                units.  If False (default), returns a list of BNGReference objects.
 
         Returns:
-            list[BNGReference]: All BNGReference objects representing squares in a square ring of radius k.
+            list[BNGReference]: All BNGReference objects representing squares in a
+                square ring of radius k.
 
         Examples:
             >>> BNGReference("SU1234").bng_kring(1)
-            [BNGReference(bng_ref_formatted=SU 11 35, resolution_label=1km), BNGReference(bng_ref_formatted=SU 12 35, resolution_label=1km),
-            BNGReference(bng_ref_formatted=SU 13 35, resolution_label=1km), BNGReference(bng_ref_formatted=SU 11 34, resolution_label=1km),
-            BNGReference(bng_ref_formatted=SU 13 34, resolution_label=1km), BNGReference(bng_ref_formatted=SU 11 33, resolution_label=1km),
-            BNGReference(bng_ref_formatted=SU 12 33, resolution_label=1km), BNGReference(bng_ref_formatted=SU 13 33, resolution_label=1km)]
+            [
+            BNGReference(bng_ref_formatted=SU 11 35, resolution_label=1km),
+            BNGReference(bng_ref_formatted=SU 12 35, resolution_label=1km),
+            BNGReference(bng_ref_formatted=SU 13 35, resolution_label=1km),
+            BNGReference(bng_ref_formatted=SU 11 34, resolution_label=1km),
+            BNGReference(bng_ref_formatted=SU 13 34, resolution_label=1km),
+            BNGReference(bng_ref_formatted=SU 11 33, resolution_label=1km),
+            BNGReference(bng_ref_formatted=SU 12 33, resolution_label=1km),
+            BNGReference(bng_ref_formatted=SU 13 33, resolution_label=1km)
+            ]
             >>> BNGReference("SU1234").bng_kring(1, return_relations=True)
-            [(BNGReference(bng_ref_formatted=SU 11 35, resolution_label=1km), -1, 1),
+            [
+            (BNGReference(bng_ref_formatted=SU 11 35, resolution_label=1km), -1, 1),
             (BNGReference(bng_ref_formatted=SU 12 35, resolution_label=1km), 0, 1),
             (BNGReference(bng_ref_formatted=SU 13 35, resolution_label=1km), 1, 1),
             (BNGReference(bng_ref_formatted=SU 11 34, resolution_label=1km), -1, 0),
             (BNGReference(bng_ref_formatted=SU 13 34, resolution_label=1km), 1, 0),
             (BNGReference(bng_ref_formatted=SU 11 33, resolution_label=1km), -1, -1),
             (BNGReference(bng_ref_formatted=SU 12 33, resolution_label=1km), 0, -1),
-            (BNGReference(bng_ref_formatted=SU 13 33, resolution_label=1km), 1, -1)]
+            (BNGReference(bng_ref_formatted=SU 13 33, resolution_label=1km), 1, -1)
+            ]
             >>> BNGReference("SU1234").bng_kring(3)
             [list of 24 BNGReference objects]
         """
-
         from osbng.traversal import bng_kring as _bng_kring
 
         return _bng_kring(self, k, return_relations=return_relations)
 
     def bng_kdisc(self, k: int, return_relations: bool = False) -> list["BNGReference"]:
-        """Returns a list of BNG reference objects representing a filled disc around the current BNG reference object
-        up to a grid distance k, including the given central BNG reference object.
+        """Returns a filled disc around the current BNG reference object.
+
+        Returns all BNGReferences up to a grid distance k, including the given central
+        BNGReference object.
 
         Returned BNG reference objects are ordered North to South then West to East.
 
         Args:
             k (int): Grid distance in units of grid squares.
-            return_relations (bool, optional): If True, returns a list of (BNGReference, dx, dy) tuples where dx, dy are integer offsets in
-                grid units.  If False (default), returns a list of BNGReference objects.
+            return_relations (bool, optional): If True, returns a list of
+                (BNGReference, dx, dy) tuples where dx, dy are integer offsets in grid
+                units.  If False (default), returns a list of BNGReference objects.
 
         Returns:
-            list[BNGReference]: All BNGReference objects representing grid squares in a square of radius k.
+            list[BNGReference]: All BNGReference objects representing grid squares in a
+                square of radius k.
 
         Examples:
             >>> BNGReference("SU1234").bng_kdisc(1)
-            [BNGReference(bng_ref_formatted=SU 11 35, resolution_label=1km), BNGReference(bng_ref_formatted=SU 12 35, resolution_label=1km),
-            BNGReference(bng_ref_formatted=SU 13 35, resolution_label=1km), BNGReference(bng_ref_formatted=SU 11 34, resolution_label=1km),
-            BNGReference(bng_ref_formatted=SU 12 34, resolution_label=1km), BNGReference(bng_ref_formatted=SU 13 34, resolution_label=1km),
-            BNGReference(bng_ref_formatted=SU 11 33, resolution_label=1km), BNGReference(bng_ref_formatted=SU 12 33, resolution_label=1km),
-            BNGReference(bng_ref_formatted=SU 13 33, resolution_label=1km)]
+            [
+            BNGReference(bng_ref_formatted=SU 11 35, resolution_label=1km),
+            BNGReference(bng_ref_formatted=SU 12 35, resolution_label=1km),
+            BNGReference(bng_ref_formatted=SU 13 35, resolution_label=1km),
+            BNGReference(bng_ref_formatted=SU 11 34, resolution_label=1km),
+            BNGReference(bng_ref_formatted=SU 12 34, resolution_label=1km),
+            BNGReference(bng_ref_formatted=SU 13 34, resolution_label=1km),
+            BNGReference(bng_ref_formatted=SU 11 33, resolution_label=1km),
+            BNGReference(bng_ref_formatted=SU 12 33, resolution_label=1km),
+            BNGReference(bng_ref_formatted=SU 13 33, resolution_label=1km)
+            ]
             >>> BNGReference("SU1234").bng_kdisc(1, return_relations=True)
-            [(BNGReference(bng_ref_formatted=SU 11 35, resolution_label=1km), -1, 1),
+            [
+            (BNGReference(bng_ref_formatted=SU 11 35, resolution_label=1km), -1, 1),
             (BNGReference(bng_ref_formatted=SU 12 35, resolution_label=1km), 0, 1),
             (BNGReference(bng_ref_formatted=SU 13 35, resolution_label=1km), 1, 1),
             (BNGReference(bng_ref_formatted=SU 11 34, resolution_label=1km), -1, 0),
@@ -572,11 +647,11 @@ class BNGReference:
             (BNGReference(bng_ref_formatted=SU 13 34, resolution_label=1km), 1, 0),
             (BNGReference(bng_ref_formatted=SU 11 33, resolution_label=1km), -1, -1),
             (BNGReference(bng_ref_formatted=SU 12 33, resolution_label=1km), 0, -1),
-            (BNGReference(bng_ref_formatted=SU 13 33, resolution_label=1km), 1, -1)]
+            (BNGReference(bng_ref_formatted=SU 13 33, resolution_label=1km), 1, -1)
+            ]
             >>> BNGReference("SU1234").bng_kdisc(3)
             [list of 49 BNGReference objects]
         """
-
         from osbng.traversal import bng_kdisc as _bng_kdisc
 
         return _bng_kdisc(self, k, return_relations=return_relations)
@@ -584,19 +659,22 @@ class BNGReference:
     def bng_distance(
         self, bng_ref2: "BNGReference", edge_to_edge: bool = False
     ) -> float:
-        """Returns the euclidean distance between the centroids of the current BNGReference object and another.
+        """Returns the euclidean distance to another BNGReference.
 
-        Note that the other BNGReference object does not necessarily need to share a common resolution.
-        When edge_to_edge = True and the two BNGReference objects have a parent-child relationship, the
-        returned distance is 0.
+        Note:
+            The other BNGReference object does not necessarily need to share a common
+            resolution.  When edge_to_edge = True and the two BNGReference objects
+            have a parent-child relationship, the returned distance is 0.
 
         Args:
             bng_ref2 (BNGReference): A BNGReference object.
-            edge_to_edge (bool, optional): If False (default), distance will be centroid-to-centroid distance.
-                If True, distance will be the shortest distance between any point in the grid squares.
+            edge_to_edge (bool, optional): If False (default), distance will be
+                centroid-to-centroid distance.  If True, distance will be the shortest
+                distance between any point in the grid squares.
 
         Returns:
-            float: The euclidean distance between the centroids of the two BNGReference objects.
+            float: The euclidean distance between the centroids of the two BNGReference
+                objects.
 
         Raises:
             TypeError: If the bng_ref2 argument is not a BNGReference object.
@@ -621,30 +699,31 @@ class BNGReference:
             ... )
             0.0
         """
-
         from osbng.traversal import bng_distance as _bng_distance
 
         return _bng_distance(self, bng_ref2, edge_to_edge=edge_to_edge)
 
-    def bng_neighbours(self):
-        """Returns a list of BNGReference objects representing the four neighbouring grid squares
-        sharing an edge with the current BNGReference.
+    def bng_neighbours(self) -> list["BNGReference"]:
+        """Returns the four neighbouring BNGReferences sharing an edge with the input.
 
         Returns:
-            list[BNGReference]: The grid squares immediately North, South, East and West of bng_ref.
+            list[BNGReference]: The grid squares immediately North, South, East and
+                West of bng_ref.
 
         Examples:
             >>> BNGRefence("SU1234").bng_neighbours()
-            [BNGReference('SU1235'), BNGReference('SU1334'), BNGReference('SU1233'), BNGReference('SU1134')]
+            [BNGReference('SU1235'), BNGReference('SU1334'),
+            BNGReference('SU1233'), BNGReference('SU1134')]
         """
-
         from osbng.traversal import bng_neighbours as _bng_neighbours
 
         return _bng_neighbours(self)
 
     def bng_is_neighbour(self, bng_ref2: "BNGReference") -> bool:
         """Returns True if the BNGReference object is a neighbour, otherwise False.
-        Neighbours are defined as grid squares that share an edge with the current BNGReference object.
+
+        Neighbours are defined as grid squares that share an edge with the current
+        BNGReference object.
 
         Args:
             bng_ref2 (BNGReference): A BNGReference object.
@@ -665,44 +744,49 @@ class BNGReference:
             False
 
         """
-
         from osbng.traversal import bng_is_neighbour as _bng_is_neighbour
 
         return _bng_is_neighbour(self, bng_ref2)
 
     def bng_dwithin(self, d: int | float) -> list["BNGReference"]:
-        """Returns a list of BNG reference objects around the current BNG reference object within an absolute distance d.
-        All squares will be returned for which any part of its boundary is within distance d of any part of
-        the BNGReference object's boundary.
+        """Returns a list of BNGReferencess within an absolute distance d.
+        
+        All squares will be returned for which any part of its boundary is within
+        distance d of any part of the BNGReference object's boundary.
 
         Args:
             d (int or float): The absolute distance d in metres.
 
         Returns:
-            list[BNGReference]: All grid squares which have any part of their geometry within distance
-                d of the current grid square
+            list[BNGReference]: All grid squares which have any part of their geometry
+                within distance d of the current grid square
 
         Examples:
             >>> BNGReference("SU1234").bng_dwithin(1000)
-            [BNGReference(bng_ref_formatted=SU 11 33, resolution_label=1km), BNGReference(bng_ref_formatted=SU 12 33, resolution_label=1km),
-            BNGReference(bng_ref_formatted=SU 13 33, resolution_label=1km), BNGReference(bng_ref_formatted=SU 11 34, resolution_label=1km),
-            BNGReference(bng_ref_formatted=SU 12 34, resolution_label=1km), BNGReference(bng_ref_formatted=SU 13 34, resolution_label=1km),
-            BNGReference(bng_ref_formatted=SU 11 35, resolution_label=1km), BNGReference(bng_ref_formatted=SU 12 35, resolution_label=1km),
-            BNGReference(bng_ref_formatted=SU 13 35, resolution_label=1km)]
+            [
+            BNGReference(bng_ref_formatted=SU 11 33, resolution_label=1km),
+            BNGReference(bng_ref_formatted=SU 12 33, resolution_label=1km),
+            BNGReference(bng_ref_formatted=SU 13 33, resolution_label=1km),
+            BNGReference(bng_ref_formatted=SU 11 34, resolution_label=1km),
+            BNGReference(bng_ref_formatted=SU 12 34, resolution_label=1km),
+            BNGReference(bng_ref_formatted=SU 13 34, resolution_label=1km),
+            BNGReference(bng_ref_formatted=SU 11 35, resolution_label=1km),
+            BNGReference(bng_ref_formatted=SU 12 35, resolution_label=1km),
+            BNGReference(bng_ref_formatted=SU 13 35, resolution_label=1km)
+            ]
             >>> BNGReference("SU1234").bng_dwithin(1001)
             [list of 21 BNGReference objects]
         """
-
         from osbng.traversal import bng_dwithin as _bng_dwithin
 
         return _bng_dwithin(self, d)
 
 
-def _validate_bngreferences(func):
-    """Decorator to validate that a BNGReference object is passed as an arg or kwarg when expected."""
+def _validate_bngreferences(func: Callable) -> Callable:
+    """Validate that a BNGReference object is passed as an arg or kwarg as expected."""
 
     @wraps(func)
-    def wrapper(*args, **kwargs):
+    def wrapper(*args: Union[BNGReference], **kwargs: Union[BNGReference]) -> Callable:
         # Get the function's signature
         signature = inspect.signature(func)
 
@@ -717,12 +801,14 @@ def _validate_bngreferences(func):
             # Find the actual object provided to the argument
             arg_val = bound_signature.arguments.get(arg_name)
 
-            # If a BNGReference is expected and the arg value is not a BNGReference, raise an error
+            # If a BNGReference is expected and the arg value is not a BNGReference,
+            # raise an error
             if (expected_type == BNGReference) and not isinstance(
                 arg_val, BNGReference
             ):
                 raise TypeError(
-                    f"A BNGReference object must be provided as the {arg_name} argument."
+                    "A BNGReference object must be provided as the"\
+                        f"{arg_name} argument."
                 )
 
         return func(*args, **kwargs)

--- a/osbng/bng_reference.py
+++ b/osbng/bng_reference.py
@@ -3,34 +3,34 @@
 BNGReference Object
 ------------------------
 
-The BNG index system uses BNG references, also known more simply as grid or tile references, to identify and index locations across 
-Great Britain (GB) into grid squares at various resolutions. 
+The BNG index system uses BNG references, also known more simply as grid or tile references, to identify and index locations across
+Great Britain (GB) into grid squares at various resolutions.
 
-The BNGReference object is a custom class that encapsulates a BNG reference string, providing properties and methods to access 
+The BNGReference object is a custom class that encapsulates a BNG reference string, providing properties and methods to access
 and manipulate the reference.
 
 British National Grid Index System
 ------------------------
 
-The Ordnance Survey (OS) BNG index system, also known as the OS National Grid, is a rectangular 
-Cartesian 700 x 1300km grid system based upon the transverse Mercator projection. In the BNG, locations 
-are specified using coordinates, eastings (x) and northings (y), measured in meters from a defined 
-origin point (0, 0) southwest of the Isles of Scilly off the coast of Cornwall, England. Values increase 
+The Ordnance Survey (OS) BNG index system, also known as the OS National Grid, is a rectangular
+Cartesian 700 x 1300km grid system based upon the transverse Mercator projection. In the BNG, locations
+are specified using coordinates, eastings (x) and northings (y), measured in meters from a defined
+origin point (0, 0) southwest of the Isles of Scilly off the coast of Cornwall, England. Values increase
 to the northeast, covering all of mainland GB and surrounding islands.
 
-The BNG is structured using a hierarchical system of grid squares at various resolutions. At its highest level, 
-the grid divides GB into 100 km by 100 km squares, each identified by a two-letter code. Successive levels 
+The BNG is structured using a hierarchical system of grid squares at various resolutions. At its highest level,
+the grid divides GB into 100 km by 100 km squares, each identified by a two-letter code. Successive levels
 of resolution further subdivide the grid squares into finer detail, down to individual 1-meter squares.
 
 BNG Reference Structure
 ------------------------
 
-Each BNG reference string consists of a series of alphanumeric characters that encode the easting and northing at 
+Each BNG reference string consists of a series of alphanumeric characters that encode the easting and northing at
 a given resolution.
 
-A BNG reference includes a 2-letter prefix that identifies the 100 km grid square. This is followed by an 
-easting and northing value, and optionally, a suffix indicating an ordinal (intercardinal) direction (NE, SE, SW, NW). 
-These suffixes represent a quadtree subdivision of the grid at the 'standard' resolutions (100km, 10km, 1km, 100m, and 10m), 
+A BNG reference includes a 2-letter prefix that identifies the 100 km grid square. This is followed by an
+easting and northing value, and optionally, a suffix indicating an ordinal (intercardinal) direction (NE, SE, SW, NW).
+These suffixes represent a quadtree subdivision of the grid at the 'standard' resolutions (100km, 10km, 1km, 100m, and 10m),
 with each direction indicating a specific quadrant.
 
 <prefix><easting value><northing value><suffix>
@@ -38,13 +38,13 @@ with each direction indicating a specific quadrant.
 There are two exceptions to this structure:
 
 1.  At the 100km resolution, a BNG reference consists only of the prefix.
-2.  At the 50km resolution, a BNG reference includes the prefix and the ordinal direction suffix but does not include easting 
+2.  At the 50km resolution, a BNG reference includes the prefix and the ordinal direction suffix but does not include easting
 or northing components.
 
 A BNG reference can be expressed at different scales, as follows:
 
 1.  100km: Identified by a two-letter code (e.g. 'TQ').
-2.  50km: Subdivides the 100 km grid into four quadrants. The grid reference adds an ordinal direction suffix (NE, NW, SE, SW) 
+2.  50km: Subdivides the 100 km grid into four quadrants. The grid reference adds an ordinal direction suffix (NE, NW, SE, SW)
     to indicate the quadrant within the 100 km square (e.g. 'TQ SW').
 3.  10km: Adds one-digit easting and northing values (e.g. 'TQ 2 3').
 4.  5km: Subdivides the 10 km square adding an ordinal suffix (e.g. 'TQ 53 SW').
@@ -61,7 +61,7 @@ BNG Reference Formatting
 
 BNG reference strings passed to a BNGReference object must adhere to the following format:
 
-- Whitespace may or may not separate the components of the reference (i.e. between the two-letter 100km grid square prefix, easting, 
+- Whitespace may or may not separate the components of the reference (i.e. between the two-letter 100km grid square prefix, easting,
   northing, and ordinal suffix).
 - If whitespace is present, it should be a single space character.
 - Whitespace can be inconsistently used between components of the reference.
@@ -70,15 +70,15 @@ BNG reference strings passed to a BNGReference object must adhere to the followi
 EPSG:27700 (OSGB36 / British National Grid)
 ------------------------
 
-The BNG system is a practical application of the EPSG:27700 (OSGB36 / British National Grid) coordinate reference system 
-(https://epsg.io/27700) which provides the geodetic framework that defines how locations defined by easting and northing coordinates 
+The BNG system is a practical application of the EPSG:27700 (OSGB36 / British National Grid) coordinate reference system
+(https://epsg.io/27700) which provides the geodetic framework that defines how locations defined by easting and northing coordinates
 and encoded as BNG references (e.g. 'ST 569 714') are projected to the grid.
 
 BNG Reference Application
 ------------------------
 
-The BNG index system is widely used by the geospatial community across GB. At each resolution, a given location can be identified with 
-increasing detail, allowing for variable accuracy depending on the geospatial application, from small-scale mapping to precise 
+The BNG index system is widely used by the geospatial community across GB. At each resolution, a given location can be identified with
+increasing detail, allowing for variable accuracy depending on the geospatial application, from small-scale mapping to precise
 survey measurements.
 """
 
@@ -348,10 +348,13 @@ class BNGReference:
         if isinstance(other, BNGReference):
             return self.bng_ref_compact == other.bng_ref_compact
         return False
-    
+
     def __lt__(self, other):
         if isinstance(other, BNGReference):
-            return (-self.resolution_metres, self.bng_ref_compact) < (-other.resolution_metres, other.bng_ref_compact)
+            return (-self.resolution_metres, self.bng_ref_compact) < (
+                -other.resolution_metres,
+                other.bng_ref_compact,
+            )
         return NotImplemented
 
     def __hash__(self):
@@ -501,7 +504,7 @@ class BNGReference:
         from osbng.hierarchy import bng_to_parent as _bng_to_parent
 
         return _bng_to_parent(self, resolution)
-    
+
     def bng_kring(self, k: int, return_relations: bool = False) -> list["BNGReference"]:
         """Returns a list of BNG reference objects representing a hollow ring around the current BNG reference object
         at a grid distance k.
@@ -510,7 +513,7 @@ class BNGReference:
 
         Args:
             k (int): Grid distance in units of grid squares.
-            return_relations (bool, optional): If True, returns a list of (BNGReference, dx, dy) tuples where dx, dy are integer offsets in 
+            return_relations (bool, optional): If True, returns a list of (BNGReference, dx, dy) tuples where dx, dy are integer offsets in
                 grid units.  If False (default), returns a list of BNGReference objects.
 
         Returns:
@@ -538,7 +541,7 @@ class BNGReference:
         from osbng.traversal import bng_kring as _bng_kring
 
         return _bng_kring(self, k, return_relations=return_relations)
-    
+
     def bng_kdisc(self, k: int, return_relations: bool = False) -> list["BNGReference"]:
         """Returns a list of BNG reference objects representing a filled disc around the current BNG reference object
         up to a grid distance k, including the given central BNG reference object.
@@ -547,7 +550,7 @@ class BNGReference:
 
         Args:
             k (int): Grid distance in units of grid squares.
-            return_relations (bool, optional): If True, returns a list of (BNGReference, dx, dy) tuples where dx, dy are integer offsets in 
+            return_relations (bool, optional): If True, returns a list of (BNGReference, dx, dy) tuples where dx, dy are integer offsets in
                 grid units.  If False (default), returns a list of BNGReference objects.
 
         Returns:
@@ -577,8 +580,10 @@ class BNGReference:
         from osbng.traversal import bng_kdisc as _bng_kdisc
 
         return _bng_kdisc(self, k, return_relations=return_relations)
-    
-    def bng_distance(self, bng_ref2: "BNGReference", edge_to_edge: bool = False) -> float:
+
+    def bng_distance(
+        self, bng_ref2: "BNGReference", edge_to_edge: bool = False
+    ) -> float:
         """Returns the euclidean distance between the centroids of the current BNGReference object and another.
 
         Note that the other BNGReference object does not necessarily need to share a common resolution.
@@ -599,7 +604,9 @@ class BNGReference:
         Examples:
             >>> BNGReference("SE1433").bng_distance(BNGRerence("SE1533"))
             1000.0
-            >>> BNGReference("SE1433").bng_distance(BNGReference("SE1533"), edge_to_edge = True)
+            >>> BNGReference("SE1433").bng_distance(
+            ...     BNGReference("SE1533"), edge_to_edge=True
+            ... )
             0.0
             >>> BNGReference("SE1433").bng_distance(BNGRerence("SE1631"))
             2828.42712474619
@@ -609,14 +616,16 @@ class BNGReference:
             42807.709586007986
             >>> BNGReference("SE").bng_distance(BNGRerence("OV"))
             141421.35623730952
-            >>> BNGReference("SU").bng_distance(BNGReference("SU2345"), edge_to_edge = True)
+            >>> BNGReference("SU").bng_distance(
+            ...     BNGReference("SU2345"), edge_to_edge=True
+            ... )
             0.0
         """
 
         from osbng.traversal import bng_distance as _bng_distance
 
         return _bng_distance(self, bng_ref2, edge_to_edge=edge_to_edge)
-    
+
     def bng_neighbours(self):
         """Returns a list of BNGReference objects representing the four neighbouring grid squares
         sharing an edge with the current BNGReference.
@@ -632,7 +641,7 @@ class BNGReference:
         from osbng.traversal import bng_neighbours as _bng_neighbours
 
         return _bng_neighbours(self)
-    
+
     def bng_is_neighbour(self, bng_ref2: "BNGReference") -> bool:
         """Returns True if the BNGReference object is a neighbour, otherwise False.
         Neighbours are defined as grid squares that share an edge with the current BNGReference object.
@@ -660,7 +669,7 @@ class BNGReference:
         from osbng.traversal import bng_is_neighbour as _bng_is_neighbour
 
         return _bng_is_neighbour(self, bng_ref2)
-    
+
     def bng_dwithin(self, d: int | float) -> list["BNGReference"]:
         """Returns a list of BNG reference objects around the current BNG reference object within an absolute distance d.
         All squares will be returned for which any part of its boundary is within distance d of any part of
@@ -694,7 +703,6 @@ def _validate_bngreferences(func):
 
     @wraps(func)
     def wrapper(*args, **kwargs):
-
         # Get the function's signature
         signature = inspect.signature(func)
 
@@ -703,7 +711,6 @@ def _validate_bngreferences(func):
 
         # Iterate through each parameter in the signature
         for arg_name in signature.parameters.keys():
-
             # Identify the expected data type
             expected_type = signature.parameters.get(arg_name).annotation
 
@@ -711,11 +718,13 @@ def _validate_bngreferences(func):
             arg_val = bound_signature.arguments.get(arg_name)
 
             # If a BNGReference is expected and the arg value is not a BNGReference, raise an error
-            if (expected_type == BNGReference) and not isinstance(arg_val, BNGReference):
+            if (expected_type == BNGReference) and not isinstance(
+                arg_val, BNGReference
+            ):
                 raise TypeError(
                     f"A BNGReference object must be provided as the {arg_name} argument."
                 )
-            
+
         return func(*args, **kwargs)
 
     return wrapper

--- a/osbng/bng_reference.py
+++ b/osbng/bng_reference.py
@@ -367,7 +367,7 @@ class BNGReference:
         }
 
     def __eq__(self, other: object):
-        """Defined equality based on self.bng_ref_compact."""
+        """Defined equality based on bng_ref_compact."""
         if isinstance(other, BNGReference):
             return self.bng_ref_compact == other.bng_ref_compact
         return False
@@ -376,8 +376,8 @@ class BNGReference:
         """Defines ordering using resolution_metres and bng_ref_compact.
         
         For two BNGReference objects, ordering is done in the following order:
-        1. Rank by self.resolution_metres, where higher resolutions are ordered first.
-        2. Rank by self.bng_ref_compact alphabetically.
+        1. Rank by resolution_metres, where higher resolutions are ordered first.
+        2. Rank by bng_ref_compact alphabetically.
 
         Example:
             >>> BNGReference("SU") < BNGReference("SU1234")
@@ -393,11 +393,11 @@ class BNGReference:
         return NotImplemented
 
     def __hash__(self):
-        """Uses self.bng_ref_compact for hashing."""
+        """Uses bng_ref_compact for hashing."""
         return hash(self.bng_ref_compact)
 
     def __repr__(self):
-        """Prints in format showing self.bng_ref_formatted and self.resolution_label."""
+        """Prints in format showing bng_ref_formatted and resolution_label."""
         return f"BNGReference(bng_ref_formatted={self.bng_ref_formatted}, "\
             f"resolution_label={self.resolution_label})"
 

--- a/osbng/hierarchy.py
+++ b/osbng/hierarchy.py
@@ -1,52 +1,74 @@
-"""Provides functionality to navigate the hierarchical structure of the British National Grid (BNG) index system.
+"""Provides functionality to navigate the hierarchical structure BNG index system.
  
-The BNG is structured using a hierarchical system of grid squares at various resolutions. At its highest level, the grid divides GB into 100 km by 100 km squares, each identified by a two-letter code. Successive levels of resolution further subdivide the grid squares into finer detail, down to individual 1-meter squares.
-This module allows for the traversal of this hierarchy by providing methods to return the parent and children of BNGReference objects at specified resolutions.
+The BNG is structured using a hierarchical system of grid squares at various
+resolutions. At its highest level, the grid divides GB into 100 km by 100 km squares,
+each identified by a two-letter code. Successive levels of resolution further subdivide
+the grid squares into finer detail, down to individual 1-meter squares. This module
+allows for the traversal of this hierarchy by providing methods to return the parent and
+children of BNGReference objects at specified resolutions.
 
 Parent and child definitions:
-- **Parent**: The parent of a BNGReference object is the grid square at the next higher (coarser) resolution level that contains the current reference. For example, the parent of a 1km grid square reference would be the 5km grid square that contains it.
-- **Children**: The children of a BNGReference object are the grid squares at the next lower (finer) resolution level that are contained within the current reference. For example, the children of a 10km grid square reference would be the 5km grid squares that it contains.
+- **Parent**: The parent of a BNGReference object is the grid square at the next higher
+    (coarser) resolution level that contains the current reference. For example, the
+    parent of a 1km grid square reference would be the 5km grid square that contains it.
+- **Children**: The children of a BNGReference object are the grid squares at the next
+    lower (finer) resolution level that are contained within the current reference. For
+    example, the children of a 10km grid square reference would be the 5km grid squares
+    that it contains.
 
 Note:
-- While parent and child derivation defaults to the next higher and lower resolution, any supported resolution in the hierarchy can be specified.
+- While parent and child derivation defaults to the next higher and lower resolution,
+    any supported resolution in the hierarchy can be specified.
 
 Supported Resolutions:
-    - The module supports the 'standard' and 'intermediate' quadtree resolutions, including 100km, 50km, 10km, 5km, 1km, 500m, 100m, 50m, 10m, 
-    5m and 1m.
-    - These resolutions passed to hierarchy functions are validated and normalised using the resolution mapping defined in the 
-      'resolution' module.
+    - The module supports the 'standard' and 'intermediate' quadtree resolutions,
+        including 100km, 50km, 10km, 5km, 1km, 500m, 100m, 50m, 10m, 5m and 1m.
+    - These resolutions passed to hierarchy functions are validated and normalised using
+        the resolution mapping defined in the 'resolution' module.
 """
 
 from osbng.bng_reference import BNGReference, _validate_bngreferences
 from osbng.errors import BNGHierarchyError
-from osbng.indexing import _validate_and_normalise_bng_resolution, xy_to_bng, bng_to_xy, bbox_to_bng
+from osbng.indexing import (
+    _validate_and_normalise_bng_resolution,
+    bbox_to_bng,
+    bng_to_xy,
+    xy_to_bng,
+)
 from osbng.resolution import BNG_RESOLUTIONS
 
 __all__ = ["bng_to_children", "bng_to_parent"]
 
 
 @_validate_bngreferences
-def bng_to_children(bng_ref: BNGReference, *, resolution: int | str | None = None) -> list[BNGReference]:
-    """Returns a list of BNGReference objects that are children of the input BNGReference object.
+def bng_to_children(
+    bng_ref: BNGReference, *, resolution: int | str | None = None
+) -> list[BNGReference]:
+    """Returns all children of the input BNGReference object.
 
-    By default, the children of the BNGReference object is defined as the BNGReference objects in the
-    next resolution down from the input BNGReference resolution. For example, 100km -> 50km.
+    By default, the children of the BNGReference object is defined as the BNGReference
+    objects in the next resolution down from the input BNGReference resolution. For
+    example, 100km -> 50km.
 
-    Any valid resolution can be provided as the child resolution, provided it is less than the
-    resolution of the input BNGReference.
+    Any valid resolution can be provided as the child resolution, provided it is less
+    than the resolution of the input BNGReference.
 
     Args:
         bng_ref (BNGReference): The BNGReference object to derive children from.
-        resolution (int | str | None, optional): The resolution of the children BNGReference objects expressed either as a
-            metre-based integer or as a string label. Defaults to None. Keyword only.
+        resolution (int | str | None, optional): The resolution of the children
+            BNGReference objects expressed either as a metre-based integer or as a
+            string label. Defaults to None. Keyword only.
 
     Returns:
-        list[BNGReference]: A list of BNGReference objects that are children of the input BNGReference object.
+        list[BNGReference]: A list of BNGReference objects that are children of the
+            input BNGReference object.
 
     Raises:
-        BNGReferenceError: If the first positional argument is not a BNGReference object.
+        BNGReferenceError: If the first positional argument is not a BNGReference
+            object.
         BNGHierarchyError: If the resolotuion of the input BNGReference object is 1m.
-        BNGHIerarchyError: If the resolution is greater than or equal to the resolution of the input BNGReference object.
+        BNGHIerarchyError: If the resolution is greater than or equal to the resolution
+            of the input BNGReference object.
         BNGResolutionError: If an invalid resolution is provided.
 
     Examples:
@@ -61,7 +83,6 @@ def bng_to_children(bng_ref: BNGReference, *, resolution: int | str | None = Non
         BNGReference(bng_ref_formatted=SU 3 6 NW, resolution_label=5km),
         BNGReference(bng_ref_formatted=SU 3 6 NE, resolution_label=5km)]
     """
-
     # Raise error if the resolution is 1m
     if bng_ref.resolution_metres == 1:
         raise BNGHierarchyError("Cannot derive children from the finest 1m resolution")
@@ -78,7 +99,8 @@ def bng_to_children(bng_ref: BNGReference, *, resolution: int | str | None = Non
     # Validate and normalise the resolution to its metre-based integer value
     validated_resolution = _validate_and_normalise_bng_resolution(resolution)
 
-    # Raise error if the validated resolution is greater than the resolution of the input BNGReference object
+    # Raise error if the validated resolution is greater than the resolution of the
+    # input BNGReference object
     if validated_resolution >= bng_ref.resolution_metres:
         raise BNGHierarchyError(
             "Resolution must be less than the resolution of input BNGReference object"
@@ -97,27 +119,34 @@ def bng_to_children(bng_ref: BNGReference, *, resolution: int | str | None = Non
 
 
 @_validate_bngreferences
-def bng_to_parent(bng_ref: BNGReference, *, resolution: int | str | None = None) -> BNGReference:
-    """Returns a BNGReference object that is the parent of the input BNGReference object.
+def bng_to_parent(
+    bng_ref: BNGReference, *, resolution: int | str | None = None
+) -> BNGReference:
+    """Returns the parent of the input BNGReference object.
 
-    By default, the parent of the BNGReference object is defined as the BNGReference in the next BNG
-    resolution up from the input BNGReference resolution. For example, 50km -> 100km.
+    By default, the parent of the BNGReference object is defined as the BNGReference in
+    the next BNG resolution up from the input BNGReference resolution. For example,
+    50km -> 100km.
 
-    Any valid resolution can be provided as the parent resolution, provided it is greater than the
-    resolution of the input BNGReference.
+    Any valid resolution can be provided as the parent resolution, provided it is
+    greater than the resolution of the input BNGReference.
 
     Args:
         bng_ref (BNGReference): The BNGReference object to derive parent from.
-        resolution (int | str | None, optional): The resolution of the parent BNGReference objects expressed either as a
-            metre-based integer or as a string label. Defaults to None. Keyword only.
+        resolution (int | str | None, optional): The resolution of the parent
+            BNGReference objects expressed either as a metre-based integer or as a
+            string label. Defaults to None. Keyword only.
 
     Returns:
-        BNGReference: A BNGReference object that is the parent of the input BNGReference object.
+        BNGReference: A BNGReference object that is the parent of the input BNGReference
+            object.
 
     Raises:
-        BNGReferenceError: If the first positional argument is not a BNGReference object.
+        BNGReferenceError: If the first positional argument is not a BNGReference
+            object.
         BNGHierarchyError: If the resolution of the input BNGReference object is 100km.
-        BNGHierarchyError: If the resolution is less than or equal to the resolution of the input BNGReference object.
+        BNGHierarchyError: If the resolution is less than or equal to the resolution of
+            the input BNGReference object.
         BNGResolutionError: If an invalid resolution is provided.
 
     Examples:
@@ -129,7 +158,6 @@ def bng_to_parent(bng_ref: BNGReference, *, resolution: int | str | None = None)
         BNGReference(bng_ref_formatted=SU 3 5, resolution_label=10km)
 
     """
-
     # Raise error if the resolution is 100km
     if bng_ref.resolution_metres == 100000:
         raise BNGHierarchyError(
@@ -148,10 +176,12 @@ def bng_to_parent(bng_ref: BNGReference, *, resolution: int | str | None = None)
     # Validate and normalise the resolution to its metre-based integer value
     validated_resolution = _validate_and_normalise_bng_resolution(resolution)
 
-    # Raise error if the validated resolution is less than the resolution of the input BNGReference object
+    # Raise error if the validated resolution is less than the resolution of the input
+    # BNGReference object
     if validated_resolution <= bng_ref.resolution_metres:
         raise BNGHierarchyError(
-            "Resolution must be greater than the resolution of input BNGReference object"
+            "Resolution must be greater than the resolution "\
+            "of input BNGReference object"
         )
 
     # Dervive coordinates of the grid square bounding box

--- a/osbng/resolution.py
+++ b/osbng/resolution.py
@@ -14,18 +14,22 @@ Supported BNG resolutions are:
 - 5m
 - 1m
 
-Relates metre-based BNG resolutions, expressed as integer values, to their respective string label representations.
-These mappings are used to indicate different resolution precision levels in BNG references and serve as the basis for validating
-and normalising resolutions within the system.
+Relates metre-based BNG resolutions, expressed as integer values, to their respective
+string label representations.  These mappings are used to indicate different resolution
+precision levels in BNG references and serve as the basis for validating and normalising
+resolutions within the system.
 
-The integer values represent spatial resolutions in metres, while the string labels provide a human-readable descriptor
-for each resolution level. For example, the numeric resolution 1000 is mapped to the label '1km'.
+The integer values represent spatial resolutions in metres, while the string labels
+provide a human-readable descriptor for each resolution level. For example, the numeric
+resolution 1000 is mapped to the label '1km'.
 
-The resolution mappings also include a flag indicating whether a given resolution represents an (intermediate) quadtree resolution.
-Quadtree resolutions are used to subdivide BNG grid squares at (standard) powers of ten resolutions into four equal quadrants,
-providing additional levels of precision for spatial indexing.
+The resolution mappings also include a flag indicating whether a given resolution
+represents an (intermediate) quadtree resolution.  Quadtree resolutions are used to
+subdivide BNG grid squares at (standard) powers of ten resolutions into four equal
+quadrants, providing additional levels of precision for spatial indexing.
 
-These resolution mappings establish the allowable values that functions and objects referencing the system can accept and process.
+These resolution mappings establish the allowable values that functions and objects
+referencing the system can accept and process.
 """
 
 __all__ = ["BNG_RESOLUTIONS"]

--- a/osbng/resolution.py
+++ b/osbng/resolution.py
@@ -1,6 +1,6 @@
 """Defines the supported resolutions for the British National Grid (BNG) index system.
 
-Supported BNG resolutions are: 
+Supported BNG resolutions are:
 
 - 100km
 - 50km
@@ -14,15 +14,15 @@ Supported BNG resolutions are:
 - 5m
 - 1m
 
-Relates metre-based BNG resolutions, expressed as integer values, to their respective string label representations. 
-These mappings are used to indicate different resolution precision levels in BNG references and serve as the basis for validating 
+Relates metre-based BNG resolutions, expressed as integer values, to their respective string label representations.
+These mappings are used to indicate different resolution precision levels in BNG references and serve as the basis for validating
 and normalising resolutions within the system.
 
 The integer values represent spatial resolutions in metres, while the string labels provide a human-readable descriptor
 for each resolution level. For example, the numeric resolution 1000 is mapped to the label '1km'.
 
 The resolution mappings also include a flag indicating whether a given resolution represents an (intermediate) quadtree resolution.
-Quadtree resolutions are used to subdivide BNG grid squares at (standard) powers of ten resolutions into four equal quadrants, 
+Quadtree resolutions are used to subdivide BNG grid squares at (standard) powers of ten resolutions into four equal quadrants,
 providing additional levels of precision for spatial indexing.
 
 These resolution mappings establish the allowable values that functions and objects referencing the system can accept and process.

--- a/osbng/traversal.py
+++ b/osbng/traversal.py
@@ -5,7 +5,7 @@ It supports spatial analyses such as distance-constrained nearest neighbour sear
 - **Neighbourhood operations**: Identify neighbouring grid squares and checking adjacency.
 - **Distance computation**: Calculate the distance between grid square centroids.
 - **Proximity queries**: Retrieve all grid squares within a specified absolute distance.
- 
+
 """
 
 import numpy as np
@@ -25,14 +25,17 @@ __all__ = [
     "bng_dwithin",
 ]
 
-def _ring_or_disc(bng_ref: BNGReference, k: int, is_disc: bool, return_relations: bool) -> list[BNGReference] | list[(BNGReference, int, int)]:
+
+def _ring_or_disc(
+    bng_ref: BNGReference, k: int, is_disc: bool, return_relations: bool
+) -> list[BNGReference] | list[(BNGReference, int, int)]:
     """Helper function to extract grid squares in a disc or ring.
 
     Args:
         bng_ref (BNGReference): A BNGReference object.
         k (int): Grid distance in units of grid squares.
         is_disc (bool): If True, returns all grid squares within distance k.  If False, only returns the outer ring.
-        return_relations (bool): If True, returns a list of (BNGReference, dx, dy) tuples where dx, dy are integer offsets in 
+        return_relations (bool): If True, returns a list of (BNGReference, dx, dy) tuples where dx, dy are integer offsets in
             grid units.  If False, returns a list of BNGReference objects.
 
     Returns:
@@ -42,14 +45,11 @@ def _ring_or_disc(bng_ref: BNGReference, k: int, is_disc: bool, return_relations
         else:
             list[BNGReference]: All BNGReference objects representing grid squares in a square ring or disc of radius k.
     """
-    
+
     # Check that k is a positive integer
-    if k<=0:
-        raise ValueError(
-            "k must be a positive integer."
-        )
-    
-    
+    if k <= 0:
+        raise ValueError("k must be a positive integer.")
+
     # Derive point location of root square
     xc, yc = bng_to_xy(bng_ref, position="centre")
 
@@ -60,35 +60,40 @@ def _ring_or_disc(bng_ref: BNGReference, k: int, is_disc: bool, return_relations
     raise_extent_warning = False
 
     # Iterate over all dx/dy within range
-    for dy in range(-k,k+1)[::-1]:
-        for dx in range(-k,k+1):
+    for dy in range(-k, k + 1)[::-1]:
+        for dx in range(-k, k + 1):
             # Include all dx/dy combinations for disks
             # Only include edges for rings
-            if is_disc | (abs(dy)==k) | (abs(dx)==k):
+            if is_disc | (abs(dy) == k) | (abs(dx) == k):
                 try:
                     ring_ref = xy_to_bng(
-                        xc+(dx*bng_ref.resolution_metres),
-                        yc+(dy*bng_ref.resolution_metres),
-                        bng_ref.resolution_metres
+                        xc + (dx * bng_ref.resolution_metres),
+                        yc + (dy * bng_ref.resolution_metres),
+                        bng_ref.resolution_metres,
                     )
                 # Catch extent errors and track whether warning is needed
                 except BNGExtentError:
                     raise_extent_warning = True
                 else:
-                    kring_refs.append((ring_ref, dx, dy)) if return_relations else kring_refs.append(ring_ref)
+                    kring_refs.append(
+                        (ring_ref, dx, dy)
+                    ) if return_relations else kring_refs.append(ring_ref)
 
     # Raise an extent warning if an error has been caught
     # Note: do this after the above, otherwise repeated warnings will be raised!
     if raise_extent_warning:
         warnings.warn(
             "One or more of the requested grid squares falls outside of the BNG index "
-            +"system extent and will not be returned."
+            + "system extent and will not be returned."
         )
 
     return kring_refs
 
+
 @_validate_bngreferences
-def bng_kring(bng_ref: BNGReference, k: int, *, return_relations: bool = False) -> list[BNGReference]:
+def bng_kring(
+    bng_ref: BNGReference, k: int, *, return_relations: bool = False
+) -> list[BNGReference]:
     """Returns a list of BNG reference objects representing a hollow ring around a given BNG reference object
     at a grid distance k.
 
@@ -97,7 +102,7 @@ def bng_kring(bng_ref: BNGReference, k: int, *, return_relations: bool = False) 
     Args:
         bng_ref (BNGReference): A BNGReference object.
         k (int): Grid distance in units of grid squares.
-        return_relations (bool, optional): If True, returns a list of (BNGReference, dx, dy) tuples where dx, dy are integer offsets in 
+        return_relations (bool, optional): If True, returns a list of (BNGReference, dx, dy) tuples where dx, dy are integer offsets in
             grid units.  If False (default), returns a list of BNGReference objects.  Keyword only.
 
     Returns:
@@ -107,12 +112,12 @@ def bng_kring(bng_ref: BNGReference, k: int, *, return_relations: bool = False) 
             and each returned BNGReference object in units of grid squares.
 
     Examples:
-        >>> bng_kring(BNGReference('SU1234'), 1)
+        >>> bng_kring(BNGReference("SU1234"), 1)
         [BNGReference(bng_ref_formatted=SU 11 35, resolution_label=1km), BNGReference(bng_ref_formatted=SU 12 35, resolution_label=1km),
         BNGReference(bng_ref_formatted=SU 13 35, resolution_label=1km), BNGReference(bng_ref_formatted=SU 11 34, resolution_label=1km),
         BNGReference(bng_ref_formatted=SU 13 34, resolution_label=1km), BNGReference(bng_ref_formatted=SU 11 33, resolution_label=1km),
         BNGReference(bng_ref_formatted=SU 12 33, resolution_label=1km), BNGReference(bng_ref_formatted=SU 13 33, resolution_label=1km)]
-        >>> bng_kring(BNGReference('SU1234'), 1, return_relations=True)
+        >>> bng_kring(BNGReference("SU1234"), 1, return_relations=True)
         [(BNGReference(bng_ref_formatted=SU 11 35, resolution_label=1km), -1, 1),
         (BNGReference(bng_ref_formatted=SU 12 35, resolution_label=1km), 0, 1),
         (BNGReference(bng_ref_formatted=SU 13 35, resolution_label=1km), 1, 1),
@@ -121,14 +126,17 @@ def bng_kring(bng_ref: BNGReference, k: int, *, return_relations: bool = False) 
         (BNGReference(bng_ref_formatted=SU 11 33, resolution_label=1km), -1, -1),
         (BNGReference(bng_ref_formatted=SU 12 33, resolution_label=1km), 0, -1),
         (BNGReference(bng_ref_formatted=SU 13 33, resolution_label=1km), 1, -1)]
-        >>> bng_kring(BNGReference('SU1234'), 3)
+        >>> bng_kring(BNGReference("SU1234"), 3)
         [list of 24 BNGReference objects]
     """
 
     return _ring_or_disc(bng_ref, k, False, return_relations)
 
+
 @_validate_bngreferences
-def bng_kdisc(bng_ref: BNGReference, k: int, *, return_relations: bool = False) -> list[BNGReference]:
+def bng_kdisc(
+    bng_ref: BNGReference, k: int, *, return_relations: bool = False
+) -> list[BNGReference]:
     """Returns a list of BNG reference objects representing a filled disc around a given BNG reference object
     up to a grid distance k, including the given central BNG reference object.
 
@@ -137,7 +145,7 @@ def bng_kdisc(bng_ref: BNGReference, k: int, *, return_relations: bool = False) 
     Args:
         bng_ref (BNGReference): A BNGReference object.
         k (int): Grid distance in units of grid squares.
-        return_relations (bool, optional): If True, returns a list of (BNGReference, dx, dy) tuples where dx, dy are integer offsets in 
+        return_relations (bool, optional): If True, returns a list of (BNGReference, dx, dy) tuples where dx, dy are integer offsets in
             grid units.  If False (default), returns a list of BNGReference objects.  Keyword only.
 
     Returns:
@@ -147,13 +155,13 @@ def bng_kdisc(bng_ref: BNGReference, k: int, *, return_relations: bool = False) 
             and each returned BNGReference object in units of grid squares.
 
     Examples:
-        >>> bng_kdisc(BNGReference('SU1234'), 1)
+        >>> bng_kdisc(BNGReference("SU1234"), 1)
         [BNGReference(bng_ref_formatted=SU 11 35, resolution_label=1km), BNGReference(bng_ref_formatted=SU 12 35, resolution_label=1km),
         BNGReference(bng_ref_formatted=SU 13 35, resolution_label=1km), BNGReference(bng_ref_formatted=SU 11 34, resolution_label=1km),
         BNGReference(bng_ref_formatted=SU 12 34, resolution_label=1km), BNGReference(bng_ref_formatted=SU 13 34, resolution_label=1km),
         BNGReference(bng_ref_formatted=SU 11 33, resolution_label=1km), BNGReference(bng_ref_formatted=SU 12 33, resolution_label=1km),
         BNGReference(bng_ref_formatted=SU 13 33, resolution_label=1km)]
-        >>> bng_kdisc(BNGReference('SU1234'), 1, return_relations=True)
+        >>> bng_kdisc(BNGReference("SU1234"), 1, return_relations=True)
         [(BNGReference(bng_ref_formatted=SU 11 35, resolution_label=1km), -1, 1),
         (BNGReference(bng_ref_formatted=SU 12 35, resolution_label=1km), 0, 1),
         (BNGReference(bng_ref_formatted=SU 13 35, resolution_label=1km), 1, 1),
@@ -163,7 +171,7 @@ def bng_kdisc(bng_ref: BNGReference, k: int, *, return_relations: bool = False) 
         (BNGReference(bng_ref_formatted=SU 11 33, resolution_label=1km), -1, -1),
         (BNGReference(bng_ref_formatted=SU 12 33, resolution_label=1km), 0, -1),
         (BNGReference(bng_ref_formatted=SU 13 33, resolution_label=1km), 1, -1)]
-        >>> bng_kdisc(BNGReference('SU1234'), 3)
+        >>> bng_kdisc(BNGReference("SU1234"), 3)
         [list of 49 BNGReference objects]
     """
 
@@ -171,9 +179,11 @@ def bng_kdisc(bng_ref: BNGReference, k: int, *, return_relations: bool = False) 
 
 
 @_validate_bngreferences
-def bng_distance(bng_ref1: BNGReference, bng_ref2: BNGReference, *, edge_to_edge: bool = False) -> float:
+def bng_distance(
+    bng_ref1: BNGReference, bng_ref2: BNGReference, *, edge_to_edge: bool = False
+) -> float:
     """Returns the euclidean distance between the centroids of two BNGReference objects.
-    
+
     Note that the two BNGReference objects do not necessarily need to share a common resolution.
     When edge_to_edge = True and bng_ref1 and bng_ref2 have a parent-child relationship, the
     returned distance is 0.
@@ -192,32 +202,41 @@ def bng_distance(bng_ref1: BNGReference, bng_ref2: BNGReference, *, edge_to_edge
         TypeError: If the first or second argument is not a BNGReference object.
 
     Examples:
-        >>> bng_distance(BNGReference('SE1433'), BNGReference('SE1533'))
+        >>> bng_distance(BNGReference("SE1433"), BNGReference("SE1533"))
         1000.0
-        >>> bng_distance(BNGReference('SE1433'), BNGReference('SE1533'), edge_to_edge = True)
+        >>> bng_distance(
+        ...     BNGReference("SE1433"), BNGReference("SE1533"), edge_to_edge=True
+        ... )
         0.0
-        >>> bng_distance(BNGReference('SE1433'), BNGReference('SE1631'))
+        >>> bng_distance(BNGReference("SE1433"), BNGReference("SE1631"))
         2828.42712474619
-        >>> bng_distance(BNGReference('SE1433'), BNGReference('SE'))
+        >>> bng_distance(BNGReference("SE1433"), BNGReference("SE"))
         39147.158262126766
-        >>> bng_distance(BNGReference('SE1433'), BNGReference('SENW'))
+        >>> bng_distance(BNGReference("SE1433"), BNGReference("SENW"))
         42807.709586007986
-        >>> bng_distance(BNGReference('SE'), BNGReference('OV'))
+        >>> bng_distance(BNGReference("SE"), BNGReference("OV"))
         141421.35623730952
-        >>> bng_distance(BNGReference('SU'), BNGReference('SU2345'), edge_to_edge = True)
+        >>> bng_distance(BNGReference("SU"), BNGReference("SU2345"), edge_to_edge=True)
         0.0
     """
 
-
     # Catch the special case of parent-child relationship when using edge-to-edge
     if (bng_ref1.resolution_metres != bng_ref2.resolution_metres) & edge_to_edge:
-
         # Identify the possible parent and child
         # Note this is required, to avoid errors by testing bng_to_parent on a BNGReference with resolution of 100km!
-        parent_candidate, child_candidate = (bng_ref1, bng_ref2) if bng_ref1.resolution_metres > bng_ref2.resolution_metres else (bng_ref2, bng_ref1)
+        parent_candidate, child_candidate = (
+            (bng_ref1, bng_ref2)
+            if bng_ref1.resolution_metres > bng_ref2.resolution_metres
+            else (bng_ref2, bng_ref1)
+        )
 
         # Return distance of 0 if one is a parent of the other
-        if bng_to_parent(child_candidate, resolution=parent_candidate.resolution_metres) == parent_candidate:
+        if (
+            bng_to_parent(
+                child_candidate, resolution=parent_candidate.resolution_metres
+            )
+            == parent_candidate
+        ):
             return 0.0
 
     # Derive the centroid of the first BNGReference object
@@ -228,15 +247,25 @@ def bng_distance(bng_ref1: BNGReference, bng_ref2: BNGReference, *, edge_to_edge
 
     # Note this must be a new if-else logic to the above special case, to catch cases where bng_ref1 and bng_ref2
     # do not share a resolution but are not parents
-    if edge_to_edge:      
+    if edge_to_edge:
         # For edge-to-edge distances, the x-distance and y-distance are the centroid-to-centroid
         # distance minus half the box width/height at either end
-        dx = 0 if centroid1[0]==centroid2[0] else abs(centroid1[0]-centroid2[0])-0.5*(bng_ref1.resolution_metres+bng_ref2.resolution_metres)
-        dy = 0 if centroid1[1]==centroid2[1] else abs(centroid1[1]-centroid2[1])-0.5*(bng_ref1.resolution_metres+bng_ref2.resolution_metres)
+        dx = (
+            0
+            if centroid1[0] == centroid2[0]
+            else abs(centroid1[0] - centroid2[0])
+            - 0.5 * (bng_ref1.resolution_metres + bng_ref2.resolution_metres)
+        )
+        dy = (
+            0
+            if centroid1[1] == centroid2[1]
+            else abs(centroid1[1] - centroid2[1])
+            - 0.5 * (bng_ref1.resolution_metres + bng_ref2.resolution_metres)
+        )
 
     else:
-        dx = centroid1[0]-centroid2[0]
-        dy = centroid1[1]-centroid2[1]
+        dx = centroid1[0] - centroid2[0]
+        dy = centroid1[1] - centroid2[1]
 
     return float(np.sqrt(dx**2 + dy**2))
 
@@ -253,13 +282,13 @@ def bng_neighbours(bng_ref: BNGReference) -> list[BNGReference]:
         list[BNGReference]: The grid squares immediately North, South, East and West of bng_ref.
 
     Examples:
-        >>> bng_neighbours(BNGReference('SU1234'))
+        >>> bng_neighbours(BNGReference("SU1234"))
         [BNGReference('SU1235'), BNGReference('SU1334'), BNGReference('SU1233'), BNGReference('SU1134')]
     """
 
     # Get the centroid of the bng square
     x, y = bng_to_xy(bng_ref, position="centre")
-    
+
     # Initialise a neighbours list
     neighbours_list = []
 
@@ -267,12 +296,12 @@ def bng_neighbours(bng_ref: BNGReference) -> list[BNGReference]:
     raise_extent_warning = False
 
     # Iterate through N,E,S,W neighbours
-    for dx,dy in [[0,1], [1,0], [0,-1], [-1,0]]:
+    for dx, dy in [[0, 1], [1, 0], [0, -1], [-1, 0]]:
         try:
             neighbour = xy_to_bng(
-                x+(dx*bng_ref.resolution_metres),
-                y+(dy*bng_ref.resolution_metres),
-                bng_ref.resolution_metres
+                x + (dx * bng_ref.resolution_metres),
+                y + (dy * bng_ref.resolution_metres),
+                bng_ref.resolution_metres,
             )
         # Catch extent errors and track whether we need to warn
         except BNGExtentError:
@@ -285,10 +314,11 @@ def bng_neighbours(bng_ref: BNGReference) -> list[BNGReference]:
     if raise_extent_warning:
         warnings.warn(
             "One or more of the requested grid squares falls outside of the BNG index "
-            +"system extent and will not be returned."
+            + "system extent and will not be returned."
         )
 
     return neighbours_list
+
 
 @_validate_bngreferences
 def bng_is_neighbour(bng_ref1: BNGReference, bng_ref2: BNGReference) -> bool:
@@ -311,7 +341,7 @@ def bng_is_neighbour(bng_ref1: BNGReference, bng_ref2: BNGReference) -> bool:
         True
         >>> bng_is_neighbour(BNGReference("SE1922"), BNGReference("SE1821"))
         False
-        >>> bng_is_neighbour(BNGReference('SU1234'), BNGReference('SU1234'))
+        >>> bng_is_neighbour(BNGReference("SU1234"), BNGReference("SU1234"))
         False
 
     """
@@ -324,7 +354,7 @@ def bng_is_neighbour(bng_ref1: BNGReference, bng_ref2: BNGReference) -> bool:
     # Otherwise check if the two BNGReference objects are neighbours
     else:
         return bng_ref2 in bng_neighbours(bng_ref1)
-    
+
 
 @_validate_bngreferences
 def bng_dwithin(bng_ref: BNGReference, d: int | float) -> list[BNGReference]:
@@ -341,21 +371,21 @@ def bng_dwithin(bng_ref: BNGReference, d: int | float) -> list[BNGReference]:
             d of bng_ref's geometry
 
     Examples:
-        >>> bng_dwithin(BNGReference('SU1234'), 1000)
+        >>> bng_dwithin(BNGReference("SU1234"), 1000)
         [BNGReference(bng_ref_formatted=SU 11 33, resolution_label=1km), BNGReference(bng_ref_formatted=SU 12 33, resolution_label=1km),
         BNGReference(bng_ref_formatted=SU 13 33, resolution_label=1km), BNGReference(bng_ref_formatted=SU 11 34, resolution_label=1km),
         BNGReference(bng_ref_formatted=SU 12 34, resolution_label=1km), BNGReference(bng_ref_formatted=SU 13 34, resolution_label=1km),
         BNGReference(bng_ref_formatted=SU 11 35, resolution_label=1km), BNGReference(bng_ref_formatted=SU 12 35, resolution_label=1km),
         BNGReference(bng_ref_formatted=SU 13 35, resolution_label=1km)]
-        >>> bng_dwithin(BNGReference('SU1234'), 1001)
+        >>> bng_dwithin(BNGReference("SU1234"), 1001)
         [list of 21 BNGReference objects]
     """
 
     # Convert distance to units of k
-    k = int(np.ceil(d/bng_ref.resolution_metres))
+    k = int(np.ceil(d / bng_ref.resolution_metres))
 
     # Get full kdisc
-    disc_refs = bng_kdisc(bng_ref, k) 
+    disc_refs = bng_kdisc(bng_ref, k)
 
     # Return only those whose centroids are within distance
-    return [r for r in disc_refs if bng_distance(bng_ref, r, edge_to_edge=True)<=d]
+    return [r for r in disc_refs if bng_distance(bng_ref, r, edge_to_edge=True) <= d]

--- a/osbng/traversal.py
+++ b/osbng/traversal.py
@@ -210,7 +210,7 @@ def bng_kdisc(
 def bng_distance(
     bng_ref1: BNGReference, bng_ref2: BNGReference, *, edge_to_edge: bool = False
 ) -> float:
-    """Returns the euclidean distance between the centroids of two BNGReference objects.
+    """Returns the euclidean distance between two BNGReference objects.
 
     Note that the two BNGReference objects do not necessarily need to share a common
     resolution.  When edge_to_edge = True and bng_ref1 and bng_ref2 have a parent-child
@@ -224,8 +224,7 @@ def bng_distance(
             distance between any point in the grid squares.  Keyword only.
 
     Returns:
-        float: The euclidean distance between the centroids of the two
-            BNGReference objects.
+        float: The euclidean distance between the two BNGReference objects.
 
     Raises:
         TypeError: If the first or second argument is not a BNGReference object.

--- a/osbng/traversal.py
+++ b/osbng/traversal.py
@@ -1,20 +1,23 @@
-"""Provides functionality for traversing and calculating distances within the British National Grid (BNG) index system.
+"""Provides functionality for traversing the British National Grid (BNG) index system.
 
-It supports spatial analyses such as distance-constrained nearest neighbour searches and 'distance within' queries by offering:
+It supports spatial analyses such as distance-constrained nearest neighbour searches and
+'distance within' queries by offering:
 - **Grid traversal**: Generate k-discs and k-rings around a given grid square.
-- **Neighbourhood operations**: Identify neighbouring grid squares and checking adjacency.
+- **Neighbourhood operations**: Identify neighbouring grid squares and checking
+    adjacency.
 - **Distance computation**: Calculate the distance between grid square centroids.
 - **Proximity queries**: Retrieve all grid squares within a specified absolute distance.
 
 """
 
-import numpy as np
 import warnings
 
-from osbng.hierarchy import bng_to_parent
-from osbng.indexing import bng_to_xy, xy_to_bng
+import numpy as np
+
 from osbng.bng_reference import BNGReference, _validate_bngreferences
 from osbng.errors import BNGExtentError, BNGNeighbourError
+from osbng.hierarchy import bng_to_parent
+from osbng.indexing import bng_to_xy, xy_to_bng
 
 __all__ = [
     "bng_kring",
@@ -34,18 +37,21 @@ def _ring_or_disc(
     Args:
         bng_ref (BNGReference): A BNGReference object.
         k (int): Grid distance in units of grid squares.
-        is_disc (bool): If True, returns all grid squares within distance k.  If False, only returns the outer ring.
-        return_relations (bool): If True, returns a list of (BNGReference, dx, dy) tuples where dx, dy are integer offsets in
-            grid units.  If False, returns a list of BNGReference objects.
+        is_disc (bool): If True, returns all grid squares within distance k.  If False,
+            only returns the outer ring.
+        return_relations (bool): If True, returns a list of (BNGReference, dx, dy)
+            tuples where dx, dy are integer offsets in grid units.  If False, returns a
+            list of BNGReference objects.
 
     Returns:
         if return_relations==True:
-            list[(BNGReference, dx, dy)]: All BNGReference objects representing grid squares in a square ring or disc of radius k,
-                with the x- and y-offsets (in grid square units) between bng_ref and each returned BNGReference.
+            list[(BNGReference, dx, dy)]: All BNGReference objects representing grid
+                squares in a square ring or disc of radius k, with the x- and y-offsets
+                (in grid square units) between bng_ref and each returned BNGReference.
         else:
-            list[BNGReference]: All BNGReference objects representing grid squares in a square ring or disc of radius k.
+            list[BNGReference]: All BNGReference objects representing grid squares in a
+                square ring or disc of radius k.
     """
-
     # Check that k is a positive integer
     if k <= 0:
         raise ValueError("k must be a positive integer.")
@@ -94,29 +100,41 @@ def _ring_or_disc(
 def bng_kring(
     bng_ref: BNGReference, k: int, *, return_relations: bool = False
 ) -> list[BNGReference]:
-    """Returns a list of BNG reference objects representing a hollow ring around a given BNG reference object
-    at a grid distance k.
+    """Returns a hollow ring around a given BNGReference object.
 
-    Returned BNG reference objects are ordered North to South then West to East, therefore not in ring order.
+    Nearby BNGReference objects at a grid distance k are returned.
+
+    Returned BNGReference objects are ordered North to South then West to East,
+        therefore not in ring order.
 
     Args:
         bng_ref (BNGReference): A BNGReference object.
         k (int): Grid distance in units of grid squares.
-        return_relations (bool, optional): If True, returns a list of (BNGReference, dx, dy) tuples where dx, dy are integer offsets in
-            grid units.  If False (default), returns a list of BNGReference objects.  Keyword only.
+        return_relations (bool, optional): If True, returns a list of
+            (BNGReference, dx, dy) tuples where dx, dy are integer offsets in grid
+            units.  If False (default), returns a list of BNGReference objects.
+            Keyword only.
 
     Returns:
-        list[BNGReference]: All BNGReference objects representing squares in a square ring of radius k.
+        list[BNGReference]: All BNGReference objects representing squares in a square
+            ring of radius k.
 
-        If return_relations is True, returns list[(BNGReference, dx, dy)], where dx and dy are the x and y offsets between bng_ref
-            and each returned BNGReference object in units of grid squares.
+        If return_relations is True, returns list[(BNGReference, dx, dy)], where dx and
+            dy are the x and y offsets between bng_ref and each returned BNGReference
+            object in units of grid squares.
 
     Examples:
         >>> bng_kring(BNGReference("SU1234"), 1)
-        [BNGReference(bng_ref_formatted=SU 11 35, resolution_label=1km), BNGReference(bng_ref_formatted=SU 12 35, resolution_label=1km),
-        BNGReference(bng_ref_formatted=SU 13 35, resolution_label=1km), BNGReference(bng_ref_formatted=SU 11 34, resolution_label=1km),
-        BNGReference(bng_ref_formatted=SU 13 34, resolution_label=1km), BNGReference(bng_ref_formatted=SU 11 33, resolution_label=1km),
-        BNGReference(bng_ref_formatted=SU 12 33, resolution_label=1km), BNGReference(bng_ref_formatted=SU 13 33, resolution_label=1km)]
+        [
+        BNGReference(bng_ref_formatted=SU 11 35, resolution_label=1km),
+        BNGReference(bng_ref_formatted=SU 12 35, resolution_label=1km),
+        BNGReference(bng_ref_formatted=SU 13 35, resolution_label=1km),
+        BNGReference(bng_ref_formatted=SU 11 34, resolution_label=1km),
+        BNGReference(bng_ref_formatted=SU 13 34, resolution_label=1km),
+        BNGReference(bng_ref_formatted=SU 11 33, resolution_label=1km),
+        BNGReference(bng_ref_formatted=SU 12 33, resolution_label=1km),
+        BNGReference(bng_ref_formatted=SU 13 33, resolution_label=1km)
+        ]
         >>> bng_kring(BNGReference("SU1234"), 1, return_relations=True)
         [(BNGReference(bng_ref_formatted=SU 11 35, resolution_label=1km), -1, 1),
         (BNGReference(bng_ref_formatted=SU 12 35, resolution_label=1km), 0, 1),
@@ -129,7 +147,6 @@ def bng_kring(
         >>> bng_kring(BNGReference("SU1234"), 3)
         [list of 24 BNGReference objects]
     """
-
     return _ring_or_disc(bng_ref, k, False, return_relations)
 
 
@@ -137,30 +154,42 @@ def bng_kring(
 def bng_kdisc(
     bng_ref: BNGReference, k: int, *, return_relations: bool = False
 ) -> list[BNGReference]:
-    """Returns a list of BNG reference objects representing a filled disc around a given BNG reference object
-    up to a grid distance k, including the given central BNG reference object.
+    """Returns a filled disc around a given BNGReference object.
+     
+    Nearby BNGReference objects within a grid distance k are returned, including the
+    given central BNGReference object.
 
-    Returned BNG reference objects are ordered North to South then West to East.
+    Returned BNGReference objects are ordered North to South then West to East.
 
     Args:
         bng_ref (BNGReference): A BNGReference object.
         k (int): Grid distance in units of grid squares.
-        return_relations (bool, optional): If True, returns a list of (BNGReference, dx, dy) tuples where dx, dy are integer offsets in
-            grid units.  If False (default), returns a list of BNGReference objects.  Keyword only.
+        return_relations (bool, optional): If True, returns a list of
+            (BNGReference, dx, dy) tuples where dx, dy are integer offsets in grid
+            units.  If False (default), returns a list of BNGReference objects.
+            Keyword only.
 
     Returns:
-        list[BNGReference]: All BNGReference objects representing grid squares in a square of radius k.
+        list[BNGReference]: All BNGReference objects representing grid squares in a
+            square of radius k.
 
-        If return_relations is True, returns list[(BNGReference, dx, dy)], where dx and dy are the x and y offsets between bng_ref
-            and each returned BNGReference object in units of grid squares.
+        If return_relations is True, returns list[(BNGReference, dx, dy)], where dx and
+            dy are the x and y offsets between bng_ref and each returned BNGReference
+            object in units of grid squares.
 
     Examples:
         >>> bng_kdisc(BNGReference("SU1234"), 1)
-        [BNGReference(bng_ref_formatted=SU 11 35, resolution_label=1km), BNGReference(bng_ref_formatted=SU 12 35, resolution_label=1km),
-        BNGReference(bng_ref_formatted=SU 13 35, resolution_label=1km), BNGReference(bng_ref_formatted=SU 11 34, resolution_label=1km),
-        BNGReference(bng_ref_formatted=SU 12 34, resolution_label=1km), BNGReference(bng_ref_formatted=SU 13 34, resolution_label=1km),
-        BNGReference(bng_ref_formatted=SU 11 33, resolution_label=1km), BNGReference(bng_ref_formatted=SU 12 33, resolution_label=1km),
-        BNGReference(bng_ref_formatted=SU 13 33, resolution_label=1km)]
+        [
+        BNGReference(bng_ref_formatted=SU 11 35, resolution_label=1km),
+        BNGReference(bng_ref_formatted=SU 12 35, resolution_label=1km),
+        BNGReference(bng_ref_formatted=SU 13 35, resolution_label=1km),
+        BNGReference(bng_ref_formatted=SU 11 34, resolution_label=1km),
+        BNGReference(bng_ref_formatted=SU 12 34, resolution_label=1km),
+        BNGReference(bng_ref_formatted=SU 13 34, resolution_label=1km),
+        BNGReference(bng_ref_formatted=SU 11 33, resolution_label=1km),
+        BNGReference(bng_ref_formatted=SU 12 33, resolution_label=1km),
+        BNGReference(bng_ref_formatted=SU 13 33, resolution_label=1km)
+        ]
         >>> bng_kdisc(BNGReference("SU1234"), 1, return_relations=True)
         [(BNGReference(bng_ref_formatted=SU 11 35, resolution_label=1km), -1, 1),
         (BNGReference(bng_ref_formatted=SU 12 35, resolution_label=1km), 0, 1),
@@ -174,7 +203,6 @@ def bng_kdisc(
         >>> bng_kdisc(BNGReference("SU1234"), 3)
         [list of 49 BNGReference objects]
     """
-
     return _ring_or_disc(bng_ref, k, True, return_relations)
 
 
@@ -184,19 +212,20 @@ def bng_distance(
 ) -> float:
     """Returns the euclidean distance between the centroids of two BNGReference objects.
 
-    Note that the two BNGReference objects do not necessarily need to share a common resolution.
-    When edge_to_edge = True and bng_ref1 and bng_ref2 have a parent-child relationship, the
-    returned distance is 0.
+    Note that the two BNGReference objects do not necessarily need to share a common
+    resolution.  When edge_to_edge = True and bng_ref1 and bng_ref2 have a parent-child
+    relationship, the returned distance is 0.
 
     Args:
         bng_ref1 (BNGReference): A BNGReference object.
         bng_ref2 (BNGReference): A BNGReference object.
-        edge_to_edge (bool, optional): If False (default), distance will be centroid-to-centroid distance.
-            If True, distance will be the shortest distance between any point in the grid squares.
-            Keyword only.
+        edge_to_edge (bool, optional): If False (default), distance will be
+            centroid-to-centroid distance.  If True, distance will be the shortest
+            distance between any point in the grid squares.  Keyword only.
 
     Returns:
-        float: The euclidean distance between the centroids of the two BNGReference objects.
+        float: The euclidean distance between the centroids of the two
+            BNGReference objects.
 
     Raises:
         TypeError: If the first or second argument is not a BNGReference object.
@@ -219,11 +248,11 @@ def bng_distance(
         >>> bng_distance(BNGReference("SU"), BNGReference("SU2345"), edge_to_edge=True)
         0.0
     """
-
     # Catch the special case of parent-child relationship when using edge-to-edge
     if (bng_ref1.resolution_metres != bng_ref2.resolution_metres) & edge_to_edge:
         # Identify the possible parent and child
-        # Note this is required, to avoid errors by testing bng_to_parent on a BNGReference with resolution of 100km!
+        # Note this is required, to avoid errors by testing bng_to_parent on a
+        # BNGReference with resolution of 100km!
         parent_candidate, child_candidate = (
             (bng_ref1, bng_ref2)
             if bng_ref1.resolution_metres > bng_ref2.resolution_metres
@@ -245,11 +274,11 @@ def bng_distance(
     # Derive the centroid of the second BNGReference object
     centroid2 = bng_to_xy(bng_ref2, position="centre")
 
-    # Note this must be a new if-else logic to the above special case, to catch cases where bng_ref1 and bng_ref2
-    # do not share a resolution but are not parents
+    # Note this must be a new if-else logic to the above special case, to catch cases
+    # where bng_ref1 and bng_ref2 do not share a resolution but are not parents
     if edge_to_edge:
-        # For edge-to-edge distances, the x-distance and y-distance are the centroid-to-centroid
-        # distance minus half the box width/height at either end
+        # For edge-to-edge distances, the x-distance and y-distance are the
+        # centroid-to-centroid distance minus half the box width/height at either end
         dx = (
             0
             if centroid1[0] == centroid2[0]
@@ -272,20 +301,20 @@ def bng_distance(
 
 @_validate_bngreferences
 def bng_neighbours(bng_ref: BNGReference) -> list[BNGReference]:
-    """Returns a list of BNGReference objects representing the four neighbouring grid squares
-    sharing an edge with the input BNGReference.
+    """Returns the four neighbouring BNGReferences sharing an edge with the input.
 
     Args:
         bng_ref (BNGReference): A BNGReference object.
 
     Returns:
-        list[BNGReference]: The grid squares immediately North, South, East and West of bng_ref.
+        list[BNGReference]: The grid squares immediately North, South, East and West
+            of bng_ref.
 
     Examples:
         >>> bng_neighbours(BNGReference("SU1234"))
-        [BNGReference('SU1235'), BNGReference('SU1334'), BNGReference('SU1233'), BNGReference('SU1134')]
+        [BNGReference('SU1235'), BNGReference('SU1334'),
+        BNGReference('SU1233'), BNGReference('SU1134')]
     """
-
     # Get the centroid of the bng square
     x, y = bng_to_xy(bng_ref, position="centre")
 
@@ -323,7 +352,9 @@ def bng_neighbours(bng_ref: BNGReference) -> list[BNGReference]:
 @_validate_bngreferences
 def bng_is_neighbour(bng_ref1: BNGReference, bng_ref2: BNGReference) -> bool:
     """Returns True if the two BNGReference objects are neighbours, otherwise False.
-    Neighbours are defined as grid squares that share an edge with the first BNGReference object.
+
+    Neighbours are defined as grid squares that share an edge with the first
+    BNGReference object.
 
     Args:
         bng_ref1 (BNGReference): A BNGReference object.
@@ -334,7 +365,8 @@ def bng_is_neighbour(bng_ref1: BNGReference, bng_ref2: BNGReference) -> bool:
 
     Raises:
         TypeError: If the first or second argument is not a BNGReference object.
-        BNGNeighbourError: If the two BNGReference objects are not at the same resolution.
+        BNGNeighbourError: If the two BNGReference objects are not at the same
+            resolution.
 
     Examples:
         >>> bng_is_neighbour(BNGReference("SE1921"), BNGReference("SE1821"))
@@ -345,11 +377,11 @@ def bng_is_neighbour(bng_ref1: BNGReference, bng_ref2: BNGReference) -> bool:
         False
 
     """
-
     # Check if the two BNGReference objects are at the same resolution
     if bng_ref1.resolution_metres != bng_ref2.resolution_metres:
         raise BNGNeighbourError(
-            "The input BNGReference objects are not the same grid resolution. The input BNGReference objects must be the same grid resolution."
+            "The input BNGReference objects are not the same grid resolution." \
+            "The inputBNGReference objects must be the same grid resolution."
         )
     # Otherwise check if the two BNGReference objects are neighbours
     else:
@@ -358,29 +390,35 @@ def bng_is_neighbour(bng_ref1: BNGReference, bng_ref2: BNGReference) -> bool:
 
 @_validate_bngreferences
 def bng_dwithin(bng_ref: BNGReference, d: int | float) -> list[BNGReference]:
-    """Returns a list of BNG reference objects around a given BNG reference object within an absolute distance d.
-    All squares will be returned for which any part of its boundary is within distance d of any part of
-    bng_ref's boundary.
+    """Returns a list of BNG reference objects within an absolute distance d.
+    
+    All squares will be returned for which any part of its boundary is within distance d
+    of any part of bng_ref's boundary.
 
     Args:
         bng_ref (BNGReference): A BNGReference object.
         d (int or float): The absolute distance d in metres.
 
     Returns:
-        list[BNGReference]: All grid squares which have any part of their geometry within distance
-            d of bng_ref's geometry
+        list[BNGReference]: All grid squares which have any part of their geometry
+            within distance d of bng_ref's geometry
 
     Examples:
         >>> bng_dwithin(BNGReference("SU1234"), 1000)
-        [BNGReference(bng_ref_formatted=SU 11 33, resolution_label=1km), BNGReference(bng_ref_formatted=SU 12 33, resolution_label=1km),
-        BNGReference(bng_ref_formatted=SU 13 33, resolution_label=1km), BNGReference(bng_ref_formatted=SU 11 34, resolution_label=1km),
-        BNGReference(bng_ref_formatted=SU 12 34, resolution_label=1km), BNGReference(bng_ref_formatted=SU 13 34, resolution_label=1km),
-        BNGReference(bng_ref_formatted=SU 11 35, resolution_label=1km), BNGReference(bng_ref_formatted=SU 12 35, resolution_label=1km),
-        BNGReference(bng_ref_formatted=SU 13 35, resolution_label=1km)]
+        [
+        BNGReference(bng_ref_formatted=SU 11 33, resolution_label=1km),
+        BNGReference(bng_ref_formatted=SU 12 33, resolution_label=1km),
+        BNGReference(bng_ref_formatted=SU 13 33, resolution_label=1km),
+        BNGReference(bng_ref_formatted=SU 11 34, resolution_label=1km),
+        BNGReference(bng_ref_formatted=SU 12 34, resolution_label=1km),
+        BNGReference(bng_ref_formatted=SU 13 34, resolution_label=1km),
+        BNGReference(bng_ref_formatted=SU 11 35, resolution_label=1km),
+        BNGReference(bng_ref_formatted=SU 12 35, resolution_label=1km),
+        BNGReference(bng_ref_formatted=SU 13 35, resolution_label=1km)
+        ]
         >>> bng_dwithin(BNGReference("SU1234"), 1001)
         [list of 21 BNGReference objects]
     """
-
     # Convert distance to units of k
     k = int(np.ceil(d / bng_ref.resolution_metres))
 

--- a/tests/test_bng_reference.py
+++ b/tests/test_bng_reference.py
@@ -1,8 +1,12 @@
 """Testing for the bng_reference module.
 
-The test cases are defined in the JSON file located at ./data/bng_reference_test_cases.json and are used to parameterise the tests for various functions in the indexing module.
-Test cases are loaded from the JSON file using the _load_test_cases function, which is defined in the utils module.
-The test cases are defined as TypedDicts, which provide a way to define the structure of the test case data.
+The test cases are defined in the JSON file located at
+./data/bng_reference_test_cases.json and are used to parameterise the tests for various
+functions in the indexing module.
+
+Test cases are loaded from the JSON file using the _load_test_cases function, which is
+defined in the utils module. The test cases are defined as TypedDicts, which provide a
+way to define the structure of the test case data.
 """
 
 from typing import TypedDict
@@ -10,11 +14,11 @@ from typing import TypedDict
 import pytest
 
 from osbng.bng_reference import (
-    _validate_bng_ref_string,
-    _get_bng_resolution_metres,
-    _get_bng_resolution_label,
-    _format_bng_ref_string,
     BNGReference,
+    _format_bng_ref_string,
+    _get_bng_resolution_label,
+    _get_bng_resolution_metres,
+    _validate_bng_ref_string,
 )
 from osbng.errors import _EXCEPTION_MAP
 from osbng.utils import _load_test_cases
@@ -25,7 +29,7 @@ class ValidateBNGRefStringTestCase(TypedDict):
 
     Attributes:
         bng_ref_string (str): The BNG reference string to validate.
-        expected (bool): True if the BNG reference is valid, False otherwise..
+        expected (bool): True if the BNG reference is valid, False otherwise.
     """
 
     bng_ref_string: str
@@ -40,7 +44,7 @@ class ValidateBNGRefStringTestCase(TypedDict):
         "_validate_bng_ref_string"
     ],
 )
-def test__validate_bng_ref_string(test_case: ValidateBNGRefStringTestCase):
+def test__validate_bng_ref_string(test_case: ValidateBNGRefStringTestCase) -> None:
     """Test _validate_bng_ref_string function with test cases from JSON file.
 
     Args:
@@ -73,7 +77,7 @@ class GetBNGResolutionMetresTestCase(TypedDict):
         "_get_bng_resolution_metres"
     ],
 )
-def test__get_bng_resolution_metres(test_case: GetBNGResolutionMetresTestCase):
+def test__get_bng_resolution_metres(test_case: GetBNGResolutionMetresTestCase) -> None:
     """Test _get_bng_resolution_metres function with test cases from JSON file.
 
     Args:
@@ -106,7 +110,7 @@ class GetBNGResolutionLabelTestCase(TypedDict):
         "_get_bng_resolution_label"
     ],
 )
-def test__get_bng_resolution_label(test_case: GetBNGResolutionLabelTestCase):
+def test__get_bng_resolution_label(test_case: GetBNGResolutionLabelTestCase) -> None:
     """Test _get_bng_resolution_label function with test cases from JSON file.
 
     Args:
@@ -139,7 +143,7 @@ class FormatBNGRefStringTestCase(TypedDict):
         "_format_bng_ref_string"
     ],
 )
-def test__format_bng_ref_string(test_case: FormatBNGRefStringTestCase):
+def test__format_bng_ref_string(test_case: FormatBNGRefStringTestCase) -> None:
     """Test _format_bng_ref_string function with test cases from JSON file.
 
     Args:
@@ -157,11 +161,14 @@ class BNGReferenceTestCase(TypedDict):
 
     Attributes:
         bng_ref_string (str): The BNG reference string.
-        expected_exception (dict[str, str]): The expected exception is a dictionary with the exception name.
+        expected_exception (dict[str, str]): The expected exception is a dictionary with
+            the exception name.
         expected_bng_ref_compact (str): The BNG reference with whitespace removed.
-        expected_bng_ref_formatted (str): The pretty-formatted version of the BNG reference with single spaces between components.
+        expected_bng_ref_formatted (str): The pretty-formatted version of the BNG
+            reference with single spaces between components.
         expected_resolution_metres (int): The resolution of the BNG reference in meters.
-        expected_resolution_label (str): The resolution of the BNG reference expressed as a descriptive string.
+        expected_resolution_label (str): The resolution of the BNG reference expressed
+            as a descriptive string.
     """
 
     bng_ref_string: str
@@ -178,11 +185,12 @@ class BNGReferenceTestCase(TypedDict):
     # Load test cases from JSON file
     _load_test_cases(file_path="./data/bng_reference_test_cases.json")["BNGReference"],
 )
-def test_bngreference(test_case: BNGReferenceTestCase):
+def test_bngreference(test_case: BNGReferenceTestCase) -> None:
     """Test BNGReference object with test cases from JSON file.
 
     Args:
-        test_case (BNGReferenceTestCase): Test case from JSON file with the following keys:
+        test_case (BNGReferenceTestCase): Test case from JSON file with the following
+        keys:
             - bng_ref_string
             - expected_bng_ref_compact
             - expected_bng_ref_formatted

--- a/tests/test_hierarchy.py
+++ b/tests/test_hierarchy.py
@@ -1,8 +1,10 @@
 """Testing for the hierarchy module.
 
-The test cases are defined in the JSON file located at ./data/hierarchy_test_cases.json and are used to parameterise the tests for various functions in the indexing module.
-Test cases are loaded from the JSON file using the _load_test_cases function, which is defined in the utils module.
-The test cases are defined as TypedDicts, which provide a way to define the structure of the test case data.
+The test cases are defined in the JSON file located at ./data/hierarchy_test_cases.json
+and are used to parameterise the tests for various functions in the indexing module.
+Test cases are loaded from the JSON file using the _load_test_cases function, which is
+defined in the utils module. The test cases are defined as TypedDicts, which provide a
+way to define the structure of the test case data.
 """
 
 from typing import TypedDict
@@ -20,9 +22,12 @@ class BNGToChildrenTestCase(TypedDict):
 
     Attributes:
         bng_ref_string (str): The BNG reference string.
-        resolution (int | str): The resolution expressed either as a metre-based integer or as a string label.
-        expected_exception (dict[str, str] | None): The expected exception is a dictionary with the exception name and optional message.
-        expected (dict[str, list[str]] | None): The expected result is a dictionary with a list of BNG reference formatted strings.
+        resolution (int | str): The resolution expressed either as a metre-based integer
+            or as a string label.
+        expected_exception (dict[str, str] | None): The expected exception is a
+            dictionary with the exception name and optional message.
+        expected (dict[str, list[str]] | None): The expected result is a dictionary with
+            a list of BNG reference formatted strings.
     """
 
     bng_ref_string: str
@@ -37,7 +42,7 @@ class BNGToChildrenTestCase(TypedDict):
     # Load test cases from JSON file
     _load_test_cases(file_path="./data/hierarchy_test_cases.json")["bng_to_children"],
 )
-def test_bng_to_children(test_case: BNGToChildrenTestCase):
+def test_bng_to_children(test_case: BNGToChildrenTestCase) -> None:
     """Test bng_to_children with test cases from JSON file.
 
     Args:
@@ -82,9 +87,12 @@ class BNGToParentTestCase(TypedDict):
 
     Attributes:
         bng_ref_string (str): The BNG reference string.
-        resolution (int | str): The resolution expressed either as a metre-based integer or as a string label.
-        expected_exception (dict[str, str] | None): The expected exception is a dictionary with the exception name.
-        expected (dict[str, str] | None): The expected result is a dictionary with the BNG reference formatted string.
+        resolution (int | str): The resolution expressed either as a metre-based integer
+            or as a string label.
+        expected_exception (dict[str, str] | None): The expected exception is a
+            dictionary with the exception name.
+        expected (dict[str, str] | None): The expected result is a dictionary with the
+            BNG reference formatted string.
     """
 
     bng_ref_string: str
@@ -99,7 +107,7 @@ class BNGToParentTestCase(TypedDict):
     # Load test cases from JSON file
     _load_test_cases(file_path="./data/hierarchy_test_cases.json")["bng_to_parent"],
 )
-def test_bng_to_parent(test_case: BNGToParentTestCase):
+def test_bng_to_parent(test_case: BNGToParentTestCase) -> None:
     """Test bng_to_parent with test cases from JSON file.
 
     Args:

--- a/tests/test_traversal.py
+++ b/tests/test_traversal.py
@@ -1,8 +1,10 @@
 """Testing for the traversal module.
 
-The test cases are defined in the JSON file located at ./data/traversal_test_cases.json and are used to parameterise the tests for various functions in the traversal module.
-Test cases are loaded from the JSON file using the _load_test_cases function, which is defined in the utils module.
-The test cases are defined as TypedDicts, which provide a way to define the structure of the test case data.
+The test cases are defined in the JSON file located at ./data/traversal_test_cases.json
+and are used to parameterise the tests for various functions in the traversal module.
+Test cases are loaded from the JSON file using the _load_test_cases function, which is
+defined in the utils module. The test cases are defined as TypedDicts, which provide a
+way to define the structure of the test case data.
 """
 
 from typing import TypedDict
@@ -11,7 +13,13 @@ import pytest
 
 from osbng.bng_reference import BNGReference
 from osbng.errors import _EXCEPTION_MAP
-from osbng.traversal import *
+from osbng.traversal import (
+    bng_distance,
+    bng_dwithin,
+    bng_is_neighbour,
+    bng_kdisc,
+    bng_kring,
+)
 from osbng.utils import _load_test_cases
 
 
@@ -22,7 +30,8 @@ class BNGDistanceTestCase(TypedDict):
         bng_ref_string_1 (str): The first BNG reference string.
         bng_ref_string_2 (str): The second BNG reference string.
         edge_to_edge (bool | None): Whether to calculate edge-to-edge distance.
-        expected (float): The expected distance between the pair of BNGReference objects.
+        expected (float): The expected distance between the pair of BNGReference
+            objects.
     """
 
     bng_ref_string_1: str
@@ -37,7 +46,7 @@ class BNGDistanceTestCase(TypedDict):
     # Load test cases from JSON file
     _load_test_cases(file_path="./data/traversal_test_cases.json")["bng_distance"],
 )
-def test_bng_distance(test_case: BNGDistanceTestCase):
+def test_bng_distance(test_case: BNGDistanceTestCase) -> None:
     """Test bng_distance with test cases from JSON file.
     
     Args:
@@ -60,7 +69,11 @@ def test_bng_distance(test_case: BNGDistanceTestCase):
         # If edge_to_edge is specified, use it in the distance calculation
         edge_to_edge = test_case["edge_to_edge"]
         # Assert that the function returns the expected result
-        distance = bng_distance(BNGReference(bng_ref1), BNGReference(bng_ref2), edge_to_edge=edge_to_edge)
+        distance = bng_distance(
+            BNGReference(bng_ref1),
+            BNGReference(bng_ref2),
+            edge_to_edge=edge_to_edge
+        )
         assert distance == test_case["expected"]
 
     else:
@@ -75,7 +88,8 @@ class BNGIsNeighbourTestCase(TypedDict):
     Attributes:
         bng_ref_string_1 (str): The first BNG reference string.
         bng_ref_string_2 (str): The second BNG reference string.
-        expected_exception (dict[str, str] | None): The expected exception is a dictionary with the exception name and message.
+        expected_exception (dict[str, str] | None): The expected exception is a
+            dictionary with the exception name and message.
         expected (bool | None): The expected result of the neighbour check.
     """
 
@@ -91,7 +105,7 @@ class BNGIsNeighbourTestCase(TypedDict):
     # Load test cases from JSON file
     _load_test_cases(file_path="./data/traversal_test_cases.json")["bng_is_neighbour"],
 )
-def test_bng_is_neighbour(test_case: BNGIsNeighbourTestCase):
+def test_bng_is_neighbour(test_case: BNGIsNeighbourTestCase) -> None:
     """Test bng_is_neighbour with test cases from JSON file.
     
     Args:
@@ -128,9 +142,12 @@ class BNGKRingTestCase(TypedDict):
     Attributes:
         bng_ref_string (str): The BNG reference string.
         k (int): The k value for the k-ring.
-        expected_warning (bool | None): The expected warning is a boolean indicating if a warning is expected.
-        expected (dict[str, list[str]] | None): The expected result is a dictionary with the key "bng_ref_formatted" and a list of formatted BNG reference strings.
-        expected_length (int | None): The expected length of the k-ring. Represents the number of BNGReference objects within k-ring.
+        expected_warning (bool | None): The expected warning is a boolean indicating if
+            a warning is expected.
+        expected (dict[str, list[str]] | None): The expected result is a dictionary with
+            the key "bng_ref_formatted" and a list of formatted BNG reference strings.
+        expected_length (int | None): The expected length of the k-ring. Represents the
+            number of BNGReference objects within k-ring.
     """
 
     bng_ref_string: str
@@ -146,7 +163,7 @@ class BNGKRingTestCase(TypedDict):
     # Load test cases from JSON file
     _load_test_cases(file_path="./data/traversal_test_cases.json")["bng_kring"],
 )
-def test_bng_kring(test_case: BNGKRingTestCase):
+def test_bng_kring(test_case: BNGKRingTestCase) -> None:
     """Test bng_kring with test cases from JSON file.
     
     Args:
@@ -156,7 +173,11 @@ def test_bng_kring(test_case: BNGKRingTestCase):
     bng_ref_string = test_case["bng_ref_string"]
     k = test_case["k"]
     # Get expected result
-    expected = None if "expected_length" in test_case else test_case["expected"]["bng_ref_formatted"]
+    expected = (
+        None
+        if "expected_length" in test_case
+        else test_case["expected"]["bng_ref_formatted"]
+    )
     expected_length = None if "expected" in test_case else test_case["expected_length"]
 
     if "expected_length" in test_case:
@@ -182,9 +203,12 @@ class BNGKDiscTestCase(TypedDict):
     Attributes:
         bng_ref_string (str): The BNG reference string.
         k (int): The k value for the k-disc.
-        expected_warning (bool | None): The expected warning is a boolean indicating if a warning is expected.
-        expected (dict[str, list[str]] | None): The expected result is a dictionary with the key "bng_ref_formatted" and a list of formatted BNG reference strings.
-        expected_length (int | None): The expected length of the k-disc. Represents the number of BNGReference objects within k-disc.
+        expected_warning (bool | None): The expected warning is a boolean indicating if
+            a warning is expected.
+        expected (dict[str, list[str]] | None): The expected result is a dictionary with
+            the key "bng_ref_formatted" and a list of formatted BNG reference strings.
+        expected_length (int | None): The expected length of the k-disc. Represents the
+            number of BNGReference objects within k-disc.
     """
 
     bng_ref_string: str
@@ -200,7 +224,7 @@ class BNGKDiscTestCase(TypedDict):
     # Load test cases from JSON file
     _load_test_cases(file_path="./data/traversal_test_cases.json")["bng_kdisc"],
 )
-def test_bng_kdisc(test_case: BNGKDiscTestCase):
+def test_bng_kdisc(test_case: BNGKDiscTestCase) -> None:
     """Test bng_kdisc with test cases from JSON file.
     
     Args:
@@ -210,7 +234,11 @@ def test_bng_kdisc(test_case: BNGKDiscTestCase):
     bng_ref_string = test_case["bng_ref_string"]
     k = test_case["k"]
     # Get expected result
-    expected = None if "expected_length" in test_case else test_case["expected"]["bng_ref_formatted"]
+    expected = (
+        None
+        if "expected_length" in test_case
+        else test_case["expected"]["bng_ref_formatted"]
+    )
     expected_length = None if "expected" in test_case else test_case["expected_length"]
 
     if "expected_length" in test_case:
@@ -236,8 +264,10 @@ class BNGKDWithinTestCase(TypedDict):
     Attributes:
         bng_ref_string (str): The BNG reference string.
         d (int): The d value for the d-within search.
-        expected (dict[str, list[str]] | None): The expected result is a dictionary with the key "bng_ref_formatted" and a list of formatted BNG reference strings.
-        expected_length (int | None): The expected length of the d-within search. Represents the number of BNGReference objects within d-within search.
+        expected (dict[str, list[str]] | None): The expected result is a dictionary with
+            the key "bng_ref_formatted" and a list of formatted BNG reference strings.
+        expected_length (int | None): The expected length of the d-within search.
+            Represents the number of BNGReference objects within d-within search.
     """
 
     bng_ref_string: str
@@ -252,18 +282,22 @@ class BNGKDWithinTestCase(TypedDict):
     # Load test cases from JSON file
     _load_test_cases(file_path="./data/traversal_test_cases.json")["bng_dwithin"],
 )
-def test_bng_dwithin(test_case: BNGKDWithinTestCase):
+def test_bng_dwithin(test_case: BNGKDWithinTestCase) -> None:
     """Test bng_dwithin with test cases from JSON file.
-    
+
     Args:
         test_case (BNGKDWithinTestCase): The test case from JSON file.
     """
     if "expected_length" in test_case:
         # Assert that the function returns the expected length
-        assert len(bng_dwithin(BNGReference(test_case["bng_ref_string"]), test_case["d"])) == test_case["expected_length"]
-    
+        assert (
+            len(bng_dwithin(BNGReference(test_case["bng_ref_string"]), test_case["d"]))
+            == test_case["expected_length"]
+        )
     else:
         # Assert that the function returns the expected result
         kring = bng_dwithin(BNGReference(test_case["bng_ref_string"]), test_case["d"])
-        assert sorted([r.bng_ref_formatted for r in kring]) == sorted(test_case["expected"]["bng_ref_formatted"])
+        assert sorted([r.bng_ref_formatted for r in kring]) == sorted(
+            test_case["expected"]["bng_ref_formatted"]
+        )
 


### PR DESCRIPTION
Linting and formatting using `Ruff` for the following `osbng` modules:
- `__init__.py`
- `bng_reference.py`
- `hierarchy.py`
- `resolution.py`
- `test_bng_reference.py`
- `test_hierarchy.py`
- `test_traversal.py`,
- `traversal.py`