### PR TITLE
Add pytest CI integration

### DIFF
--- a/.github/workflows/run-pytest.yml
+++ b/.github/workflows/run-pytest.yml
@@ -1,6 +1,6 @@
 name: Run Unit Test via Pytest  
   
-on: [pull_request]  
+on: [push]  
   
 jobs:  
   build:  

--- a/.github/workflows/run-pytest.yml
+++ b/.github/workflows/run-pytest.yml
@@ -10,7 +10,7 @@ jobs:
         python-version: ["3.13"]  
   
     steps:  
-      - uses: actions/checkout@v3  
+      - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}  
         uses: actions/setup-python@v4  
         with:  
@@ -22,4 +22,5 @@ jobs:
           pip install -r testing-requirements.txt
       - name: Test with pytest  
         run: |  
+          cd tests
           coverage run -m pytest . -s

--- a/.github/workflows/run-pytest.yml
+++ b/.github/workflows/run-pytest.yml
@@ -22,4 +22,4 @@ jobs:
           pip install -r testing-requirements.txt
       - name: Test with pytest  
         run: |  
-          coverage run -m pytest -s
+          coverage run -m pytest . -s

--- a/.github/workflows/run-pytest.yml
+++ b/.github/workflows/run-pytest.yml
@@ -1,0 +1,25 @@
+name: Run Unit Test via Pytest  
+  
+on: [pull_request]  
+  
+jobs:  
+  build:  
+    runs-on: ubuntu-latest  
+    strategy:  
+      matrix:  
+        python-version: ["3.13"]  
+  
+    steps:  
+      - uses: actions/checkout@v3  
+      - name: Set up Python ${{ matrix.python-version }}  
+        uses: actions/setup-python@v4  
+        with:  
+          python-version: ${{ matrix.python-version }}  
+      - name: Install dependencies  
+        run: |  
+          cd tests
+          python -m pip install --upgrade pip  
+          pip install -r testing-requirements.txt
+      - name: Test with pytest  
+        run: |  
+          coverage run -m pytest -s

--- a/.github/workflows/run-pytest.yml
+++ b/.github/workflows/run-pytest.yml
@@ -1,6 +1,6 @@
 name: Run Unit Test via Pytest  
   
-on: [push]  
+on: [pull_request]  
   
 jobs:  
   build:  

--- a/tests/testing-requirements.txt
+++ b/tests/testing-requirements.txt
@@ -3,3 +3,4 @@ geopandas>=1.0.0
 matplotlib
 pytest
 tox
+coverage

--- a/tests/testing-requirements.txt
+++ b/tests/testing-requirements.txt
@@ -1,0 +1,5 @@
+shapely>=2.0.0
+geopandas>=1.0.0
+matplotlib
+pytest
+tox


### PR DESCRIPTION
Resolves #34.

This PR adds configuration for a GitHub Action triggered by a pull request to run `pytest` in the `tests` directory.  The following changes are made:
- New file `.github/workflows/run-pytest.yml`, which sets up the GitHub Action.

<s> - New file `tests/testing-requirements.txt` which configures the Python packages to be installed prior to running `pytest`.  I don't think there's an easy way to use the `pyproject.toml` for this purpose (and in theory we might want the `pytest` package to be only added to the `testing-requirements.txt` rather than `pyproject.toml` since it's not a dependency of the main package anyway?).<s>