### PR TITLE
Fix/kwarg only syntax consistency in methods

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -40,7 +40,7 @@ keywords:
   - british national grid
   - ordnance survey grid
 license: MIT
-version: 0.3.3
+version: 0.4.0
 date-released: 2025-08-15
 preferred-citation:
   type: software
@@ -50,5 +50,5 @@ preferred-citation:
   institution:
     name: Ordnance Survey Ltd
   year: '2025'
-  version: 0.3.2
+  version: 0.4.0
   repository-code: https://github.com/OrdnanceSurvey/osbng-py

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -16,7 +16,7 @@ sys.path.insert(0, str(PROJECT_ROOT))
 project = "osbng"
 author = "Ordnance Survey"
 copyright = f"{datetime.now().year}, {author}"
-release = "0.3.3"
+release = "0.4.0"
 
 # Sphinx extensions
 extensions = [

--- a/osbng/__init__.py
+++ b/osbng/__init__.py
@@ -46,4 +46,4 @@ __all__ = [
     "geom_to_bng",
     "geom_to_bng_intersection",
 ]
-__version__ = "0.3.3"
+__version__ = "0.4.0"

--- a/osbng/bng_reference.py
+++ b/osbng/bng_reference.py
@@ -477,7 +477,7 @@ class BNGReference:
         )
 
     def bng_to_xy(
-        self, position: str = "lower-left"
+        self, *, position: str = "lower-left"
     ) -> tuple[int | float, int | float]:
         """Returns easting and northing coordinates of this ``BNGReference``.
 
@@ -511,7 +511,7 @@ class BNGReference:
         """
         from osbng.indexing import bng_to_xy as _bng_to_xy
 
-        return _bng_to_xy(self, position)
+        return _bng_to_xy(self, position=position)
 
     def bng_to_bbox(self) -> tuple[int, int, int, int]:
         """Returns grid square bounding box coordinates of this ``BNGReference``.
@@ -562,7 +562,7 @@ class BNGReference:
         return _bng_to_grid_geom(self)
 
     def bng_to_children(
-        self, resolution: int | str | None = None
+        self, *, resolution: int | str | None = None
     ) -> list["BNGReference"]:
         """Returns a list of child ``BNGReference`` objects of this ``BNGReference``.
 
@@ -610,9 +610,9 @@ class BNGReference:
         """
         from osbng.hierarchy import bng_to_children as _bng_to_children
 
-        return _bng_to_children(self, resolution)
+        return _bng_to_children(self, resolution=resolution)
 
-    def bng_to_parent(self, resolution: int | str | None = None) -> "BNGReference":
+    def bng_to_parent(self, *, resolution: int | str | None = None) -> "BNGReference":
         """Returns the ``BNGReference`` that is the parent of this ``BNGReference``.
 
         By default, the parent of the :class:`~osbng.bng_reference.BNGReference` object
@@ -655,9 +655,11 @@ class BNGReference:
         """
         from osbng.hierarchy import bng_to_parent as _bng_to_parent
 
-        return _bng_to_parent(self, resolution)
+        return _bng_to_parent(self, resolution=resolution)
 
-    def bng_kring(self, k: int, return_relations: bool = False) -> list["BNGReference"]:
+    def bng_kring(
+        self, k: int, *, return_relations: bool = False
+    ) -> list["BNGReference"]:
         """Returns a hollow ring of BNGReference objects around this ``BNGReference``.
 
         Returns all :class:`~osbng.bng_reference.BNGReference` objects at a grid
@@ -713,7 +715,9 @@ class BNGReference:
 
         return _bng_kring(self, k, return_relations=return_relations)
 
-    def bng_kdisc(self, k: int, return_relations: bool = False) -> list["BNGReference"]:
+    def bng_kdisc(
+        self, k: int, *, return_relations: bool = False
+    ) -> list["BNGReference"]:
         """Returns a filled disc of BNGReference objects around this ``BNGReference``.
 
         Returns all :class:`~osbng.bng_reference.BNGReference` objects up to a grid
@@ -773,7 +777,7 @@ class BNGReference:
         return _bng_kdisc(self, k, return_relations=return_relations)
 
     def bng_distance(
-        self, bng_ref2: "BNGReference", edge_to_edge: bool = False
+        self, bng_ref2: "BNGReference", *, edge_to_edge: bool = False
     ) -> float:
         """Returns the euclidean distance between bng_ref2 and this ``BNGReference``.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "osbng"
-version = "0.3.3"
+version = "0.4.0"
 description = "A Python package supporting geospatial grid indexing and interaction with Ordnance Survey's British National Grid index system"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
This PR resolves #44, by forcing the instance methods of `BNGReference` and their equivalent functions to have parity in the behaviour of keyword-only arguments.  **This is therefore a breaking change.**

This PR also resolves the related #46, by passing the `resolution` as a keyword argument to the relevant functions in the `.bng_to_children()` and `.bng_to_parent()` instance methods of `BNGReference`.

Due to the breaking changes, this PR also bumps the minor version number to `0.4.0`.